### PR TITLE
Improve markdown fence stripping with permissive fallback

### DIFF
--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -204,6 +204,7 @@ func TestStripMarkdownFromResponse(t *testing.T) {
 		input    string
 		expected string
 	}{
+		// Strict match cases (entire text is fenced)
 		{
 			name:     "plain_json",
 			input:    `{"key": "value"}`,
@@ -233,6 +234,27 @@ func TestStripMarkdownFromResponse(t *testing.T) {
 			name:     "no_closing_fence_unchanged",
 			input:    "```json\n{\"key\": \"value\"}",
 			expected: "```json\n{\"key\": \"value\"}",
+		},
+		// Permissive match cases (preamble before fenced JSON)
+		{
+			name:     "preamble_with_fenced_json",
+			input:    "Here is the JSON:\n```json\n{\"key\": \"value\"}\n```",
+			expected: `{"key": "value"}`,
+		},
+		{
+			name:     "preamble_with_fenced_array",
+			input:    "The results are:\n```json\n[{\"id\": 1}, {\"id\": 2}]\n```",
+			expected: `[{"id": 1}, {"id": 2}]`,
+		},
+		{
+			name:     "explanation_with_fenced_json",
+			input:    "Based on my analysis:\n\n```json\n{\"result\": true}\n```\n\nHope this helps!",
+			expected: `{"result": true}`,
+		},
+		{
+			name:     "nested_json_in_fence",
+			input:    "```json\n{\"outer\": {\"inner\": \"value\"}}\n```",
+			expected: `{"outer": {"inner": "value"}}`,
 		},
 	}
 


### PR DESCRIPTION
## Summary

When models add preamble text before fenced JSON (e.g., `Here is the JSON:`), the strict regex that requires fences at start/end of string fails, causing JSON parse errors like:

```
invalid character '`' looking for beginning of value
```

## Changes

Adds a two-stage markdown fence stripping approach:

1. **Strict match** (existing): Handles responses where entire text is wrapped in fences
2. **Permissive fallback** (new): Extracts JSON objects/arrays from anywhere within fences

This handles:
- Preamble text before fenced JSON (`Here is the result:\n\`\`\`json\n{...}\`\`\``)
- Trailing text after fenced JSON
- Fenced JSON that doesn't start at position 0

## Testing

Added test cases for permissive matching scenarios:
- `preamble_with_fenced_json`
- `preamble_with_fenced_array`  
- `explanation_with_fenced_json`
- `nested_json_in_fence`

All existing tests continue to pass.