### PR TITLE
Map genai.ThinkingConfig to Anthropic extended thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.1.9] - Map genai.ThinkingConfig to Anthropic extended thinking
+
+- Map `genai.ThinkingConfig` fields (`ThinkingLevel`, `ThinkingBudget`, `IncludeThoughts`) to Anthropic's `Thinking` parameter in both standard and Beta API requests
+- `ThinkingLevel: HIGH` enables thinking with a 10,000 token budget; `LOW` uses the minimum 1,024 tokens
+- An explicit `ThinkingBudget` always takes precedence over level defaults
+- `IncludeThoughts: true` without a level or budget enables thinking with a 10,000 token default
+
 ## [v0.1.8] - Rename VertexRegion to VertexLocation and rename env var
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go get github.com/Alcova-AI/adk-anthropic-go
 - Streaming and non-streaming responses
 - Tool/function calling with `ToolConfig` support (tool_choice: auto, any, specific tool)
 - Structured output via `ResponseSchema` (guaranteed schema-compliant JSON)
-- Extended thinking (mapped to `genai.Part` with `Thought=true`)
+- Extended thinking with `ThinkingConfig` support (level, budget, and response mapping to `genai.Part` with `Thought=true`)
 - Multimodal inputs (text, images)
 - PDF document processing (beta)
 - System instructions
@@ -152,6 +152,38 @@ Mode mapping:
 | `ModeAny` | `any` (must use a tool) |
 | `ModeAny` + single `AllowedFunctionNames` | `tool` (must use the named tool) |
 | `ModeNone` | omitted (no tool use) |
+
+### Extended Thinking (ThinkingConfig)
+
+Use `ThinkingConfig` to enable extended thinking:
+
+```go
+config := &genai.GenerateContentConfig{
+	ThinkingConfig: &genai.ThinkingConfig{
+		ThinkingLevel: genai.ThinkingLevelHigh,
+	},
+}
+```
+
+Or set an explicit token budget:
+
+```go
+config := &genai.GenerateContentConfig{
+	ThinkingConfig: &genai.ThinkingConfig{
+		ThinkingBudget: ptr(int32(5000)),
+	},
+}
+```
+
+Mapping:
+| `genai` ThinkingConfig | Anthropic Behavior |
+|---|---|
+| `ThinkingLevel: HIGH` | Thinking enabled, 10,000 token budget |
+| `ThinkingLevel: LOW` | Thinking enabled, 1,024 token budget (minimum) |
+| `ThinkingBudget` set | Thinking enabled with the exact budget (overrides level defaults) |
+| `IncludeThoughts: true` (no level/budget) | Thinking enabled, 10,000 token budget |
+
+Thinking blocks in responses are mapped to `genai.Part` with `Thought=true` and `ThoughtSignature` preserved for multi-turn conversations.
 
 ## License
 

--- a/anthropic.go
+++ b/anthropic.go
@@ -412,6 +412,11 @@ func (m *anthropicModel) convertRequest(req *model.LLMRequest) (anthropic.Messag
 			}
 			params.ToolChoice = toolChoice
 		}
+
+		// Thinking config
+		if req.Config.ThinkingConfig != nil {
+			params.Thinking = converters.ThinkingConfigToAnthropicThinking(req.Config.ThinkingConfig)
+		}
 	}
 
 	return params, nil
@@ -472,6 +477,11 @@ func (m *anthropicModel) convertBetaRequest(req *model.LLMRequest) (anthropic.Be
 				return anthropic.BetaMessageNewParams{}, err
 			}
 			params.ToolChoice = toolChoice
+		}
+
+		// Thinking config
+		if req.Config.ThinkingConfig != nil {
+			params.Thinking = converters.ThinkingConfigToBetaAnthropicThinking(req.Config.ThinkingConfig)
 		}
 	}
 

--- a/converters/request.go
+++ b/converters/request.go
@@ -687,6 +687,48 @@ func SystemInstructionToBetaSystem(instruction *genai.Content) []anthropic.BetaT
 	return blocks
 }
 
+// resolveThinkingBudget returns the thinking token budget for a ThinkingConfig,
+// or -1 if thinking should not be enabled.
+func resolveThinkingBudget(cfg *genai.ThinkingConfig) int64 {
+	if cfg == nil {
+		return -1
+	}
+
+	// Explicit budget always takes precedence.
+	if cfg.ThinkingBudget != nil {
+		return int64(*cfg.ThinkingBudget)
+	}
+
+	// Map thinking level to a default budget.
+	switch cfg.ThinkingLevel {
+	case genai.ThinkingLevelHigh:
+		return 10000
+	case genai.ThinkingLevelLow:
+		return 1024
+	default:
+		if cfg.IncludeThoughts {
+			return 10000
+		}
+		return -1
+	}
+}
+
+// ThinkingConfigToAnthropicThinking converts a genai ThinkingConfig to an Anthropic ThinkingConfigParamUnion.
+func ThinkingConfigToAnthropicThinking(cfg *genai.ThinkingConfig) anthropic.ThinkingConfigParamUnion {
+	if budget := resolveThinkingBudget(cfg); budget >= 0 {
+		return anthropic.ThinkingConfigParamOfEnabled(budget)
+	}
+	return anthropic.ThinkingConfigParamUnion{}
+}
+
+// ThinkingConfigToBetaAnthropicThinking converts a genai ThinkingConfig to an Anthropic BetaThinkingConfigParamUnion.
+func ThinkingConfigToBetaAnthropicThinking(cfg *genai.ThinkingConfig) anthropic.BetaThinkingConfigParamUnion {
+	if budget := resolveThinkingBudget(cfg); budget >= 0 {
+		return anthropic.BetaThinkingConfigParamOfEnabled(budget)
+	}
+	return anthropic.BetaThinkingConfigParamUnion{}
+}
+
 // mergeConsecutiveBetaMessages merges consecutive Beta messages with the same role.
 func mergeConsecutiveBetaMessages(messages []anthropic.BetaMessageParam) []anthropic.BetaMessageParam {
 	if len(messages) <= 1 {


### PR DESCRIPTION
## Summary

- Add converter functions (`ThinkingConfigToAnthropicThinking`, `ThinkingConfigToBetaAnthropicThinking`) that map `genai.ThinkingConfig` to Anthropic's `Thinking` parameter
- Wire up `ThinkingConfig` in both `convertRequest` (standard API) and `convertBetaRequest` (Beta API)
- `ThinkingLevel: HIGH` → 10,000 token budget, `LOW` → 1,024 (minimum), explicit `ThinkingBudget` overrides level defaults
- `IncludeThoughts: true` without a level/budget enables thinking with a 10,000 token default
- Update README with ThinkingConfig usage docs and mapping table
- Add CHANGELOG entry for v0.1.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)