### PR TITLE
Drop thinking when tool_choice forces a tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.1.17] - Drop thinking under forced tool_choice
+
+- Anthropic rejects extended thinking (manual or adaptive) when `tool_choice.type` is `"tool"` or `"any"`. Sent together, the API may either return a 400 or — worse — silently produce a text/thinking response with no `tool_use` block, which looks to callers like the model refused to use the tool.
+- The genai-side shape that lands callers in this trap is easy to write by accident: `ToolConfig.FunctionCallingConfig.Mode = ModeAny` (with or without `AllowedFunctionNames`) maps to forced `tool_choice`, and `ThinkingConfig.ThinkingLevel ∈ {Low, Medium, High}` on adaptive-capable models (Sonnet 4.6+, Opus 4.6+, Mythos Preview) maps to adaptive thinking. Both happily go on the wire.
+- `convertRequest` now drops `params.Thinking` and `params.OutputConfig.Effort` whenever `params.ToolChoice` is forced. The forced `tool_choice` is the load-bearing semantic — the caller has pinned the response shape — so downgrading thinking is the less-surprising of the two corrections.
+- New exported helper `converters.IsForcedToolUse(tc anthropic.ToolChoiceUnionParam) bool` for callers that want the same check.
+
 ## [v0.1.16] - Model-aware adaptive thinking + effort mapping
 
 - Upgrade `anthropic-sdk-go` from v1.28.0 to v1.43.0 — picks up `ModelClaudeOpus4_7`, `ModelClaudeMythosPreview`, and `OutputConfigEffortXhigh` constants.

--- a/anthropic.go
+++ b/anthropic.go
@@ -353,6 +353,19 @@ func (m *anthropicModel) convertRequest(req *model.LLMRequest) (anthropic.Messag
 		params.OutputConfig.Effort = mapping.Effort
 	}
 
+	// Anthropic rejects extended thinking (manual or adaptive) combined with
+	// forced tool use (tool_choice.type = "tool" or "any"). When both are
+	// requested, the API may either 400 or — worse — silently produce a
+	// text/thinking response with no tool_use block, which looks to callers
+	// like the model just refused to call the tool. The forced tool_choice
+	// is the load-bearing semantic (the caller has pinned the response
+	// shape), so drop the thinking parameter on this side of the wire.
+	// Effort is meaningless without adaptive thinking, so clear it too.
+	if converters.IsForcedToolUse(params.ToolChoice) {
+		params.Thinking = anthropic.ThinkingConfigParamUnion{}
+		params.OutputConfig.Effort = ""
+	}
+
 	if m.promptCaching != nil {
 		applyCacheBreakpoints(&params, m.promptCaching)
 	}

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -253,6 +253,198 @@ func TestConvertRequest_NilConfigLeavesThinkingOffOnNonAdaptive(t *testing.T) {
 	}
 }
 
+// TestConvertRequest_ForcedToolUseDropsThinking locks in the workaround for
+// Anthropic's "forced tool use cannot be combined with extended thinking"
+// constraint. The combination is easy to land into via the genai shape:
+//
+//   - ToolConfig.FunctionCallingConfig.Mode = ModeAny (with or without an
+//     AllowedFunctionNames whitelist) maps to tool_choice.type "any" or "tool".
+//   - ThinkingConfig.ThinkingLevel ∈ {Low, Medium, High} maps to adaptive
+//     thinking on Sonnet 4.6+ / Opus 4.6+ / Mythos.
+//
+// Sent together, Anthropic may ignore tool_choice and reply with text or
+// thinking blocks — which looks to callers like the model refused to use the
+// tool. The converter drops thinking when tool_choice is forced; this test
+// guards that contract for both the specific-tool ("OfTool") and
+// any-tool ("OfAny") shapes, plus the adaptive and manual thinking variants.
+func TestConvertRequest_ForcedToolUseDropsThinking(t *testing.T) {
+	toolDecl := &genai.Tool{
+		FunctionDeclarations: []*genai.FunctionDeclaration{
+			{
+				Name:        "save_thing",
+				Description: "Save a thing.",
+				Parameters: &genai.Schema{
+					Type:     genai.TypeObject,
+					Required: []string{"id"},
+					Properties: map[string]*genai.Schema{
+						"id": {Type: genai.TypeString},
+					},
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		name       string
+		modelName  string // adaptive-capable vs manual-only
+		toolConfig *genai.ToolConfig
+		thinking   *genai.ThinkingConfig
+	}{
+		{
+			name:      "adaptive_model_specific_tool",
+			modelName: "claude-sonnet-4-6",
+			toolConfig: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode:                 genai.FunctionCallingConfigModeAny,
+					AllowedFunctionNames: []string{"save_thing"},
+				},
+			},
+			thinking: &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelLow},
+		},
+		{
+			name:      "adaptive_model_any_tool",
+			modelName: "claude-sonnet-4-6",
+			toolConfig: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode: genai.FunctionCallingConfigModeAny,
+				},
+			},
+			thinking: &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelHigh},
+		},
+		{
+			name:      "adaptive_model_nil_thinking_config_defaults_to_adaptive",
+			modelName: "claude-sonnet-4-6",
+			toolConfig: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode:                 genai.FunctionCallingConfigModeAny,
+					AllowedFunctionNames: []string{"save_thing"},
+				},
+			},
+			thinking: nil, // adaptive-capable + nil → adaptive defaults; must still be dropped.
+		},
+		{
+			name:      "manual_model_specific_tool",
+			modelName: "claude-haiku-4-5",
+			toolConfig: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode:                 genai.FunctionCallingConfigModeAny,
+					AllowedFunctionNames: []string{"save_thing"},
+				},
+			},
+			thinking: &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelHigh},
+		},
+		{
+			name:      "manual_model_explicit_budget",
+			modelName: "claude-haiku-4-5",
+			toolConfig: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode: genai.FunctionCallingConfigModeAny,
+				},
+			},
+			thinking: &genai.ThinkingConfig{ThinkingBudget: ptrInt32(5000)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &anthropicModel{
+				name:             tc.modelName,
+				variant:          VariantAnthropicAPI,
+				defaultMaxTokens: defaultMaxTokens,
+			}
+
+			req := &model.LLMRequest{
+				Contents: []*genai.Content{
+					genai.NewContentFromText("Hello", "user"),
+				},
+				Config: &genai.GenerateContentConfig{
+					Tools:          []*genai.Tool{toolDecl},
+					ToolConfig:     tc.toolConfig,
+					ThinkingConfig: tc.thinking,
+				},
+			}
+
+			params, err := m.convertRequest(req)
+			if err != nil {
+				t.Fatalf("convertRequest() error = %v", err)
+			}
+
+			if params.Thinking.OfAdaptive != nil || params.Thinking.OfEnabled != nil {
+				t.Errorf("expected Thinking to be cleared under forced tool_choice, got %+v", params.Thinking)
+			}
+			if params.OutputConfig.Effort != "" {
+				t.Errorf("expected OutputConfig.Effort to be cleared, got %q", params.OutputConfig.Effort)
+			}
+			if params.ToolChoice.OfAny == nil && params.ToolChoice.OfTool == nil {
+				t.Errorf("expected forced ToolChoice (OfAny or OfTool) to be preserved, got %+v", params.ToolChoice)
+			}
+		})
+	}
+}
+
+// TestConvertRequest_AutoToolUseKeepsThinking ensures the conflict resolution
+// only fires when tool_choice is genuinely forced. ModeAuto, ModeNone, and no
+// ToolConfig at all must all preserve the thinking parameter that the caller
+// (or the model-aware defaults) selected.
+func TestConvertRequest_AutoToolUseKeepsThinking(t *testing.T) {
+	cases := []struct {
+		name       string
+		toolConfig *genai.ToolConfig
+	}{
+		{
+			name: "auto_mode",
+			toolConfig: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode: genai.FunctionCallingConfigModeAuto,
+				},
+			},
+		},
+		{
+			name: "none_mode",
+			toolConfig: &genai.ToolConfig{
+				FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode: genai.FunctionCallingConfigModeNone,
+				},
+			},
+		},
+		{
+			name:       "no_tool_config",
+			toolConfig: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &anthropicModel{
+				name:             "claude-sonnet-4-6",
+				variant:          VariantAnthropicAPI,
+				defaultMaxTokens: defaultMaxTokens,
+			}
+
+			req := &model.LLMRequest{
+				Contents: []*genai.Content{
+					genai.NewContentFromText("Hello", "user"),
+				},
+				Config: &genai.GenerateContentConfig{
+					ToolConfig:     tc.toolConfig,
+					ThinkingConfig: &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelLow},
+				},
+			}
+
+			params, err := m.convertRequest(req)
+			if err != nil {
+				t.Fatalf("convertRequest() error = %v", err)
+			}
+
+			if params.Thinking.OfAdaptive == nil {
+				t.Errorf("expected adaptive thinking to be preserved when tool_choice is not forced, got %+v", params.Thinking)
+			}
+		})
+	}
+}
+
+func ptrInt32(v int32) *int32 { return &v }
+
 func TestEmbedSchemaAsSystemPrompt(t *testing.T) {
 	schema := &genai.Schema{
 		Type:     genai.TypeObject,

--- a/converters/tools.go
+++ b/converters/tools.go
@@ -377,3 +377,14 @@ func ToolConfigToToolChoice(config *genai.ToolConfig) (anthropic.ToolChoiceUnion
 		return anthropic.ToolChoiceUnionParam{}, fmt.Errorf("unexpected tool choice kind: %d", resolved.kind)
 	}
 }
+
+// IsForcedToolUse reports whether the given tool_choice forces the model to
+// emit a tool_use block — i.e. tool_choice.type is "any" or "tool". Auto and
+// the zero value (no tool_choice on the wire) are not forced.
+//
+// Anthropic rejects the combination of forced tool use and extended thinking
+// (both manual and adaptive); callers should drop the thinking parameter when
+// this returns true. See https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#forced-tool-use-and-extended-thinking
+func IsForcedToolUse(tc anthropic.ToolChoiceUnionParam) bool {
+	return tc.OfAny != nil || tc.OfTool != nil
+}


### PR DESCRIPTION
## Problem

Anthropic rejects extended thinking — manual or adaptive — when `tool_choice.type` is `"tool"` or `"any"`. Sent together, the API either returns a 400 or, worse, silently produces a text/thinking response with no `tool_use` block, which looks to callers like the model refused to call the tool.

The genai-side shape that lands callers in this trap is easy to write by accident:

- `ToolConfig.FunctionCallingConfig.Mode = ModeAny` (with or without `AllowedFunctionNames`) maps to forced `tool_choice` — `"any"` or specific-tool.
- `ThinkingConfig.ThinkingLevel ∈ {Low, Medium, High}` on adaptive-capable models (Sonnet 4.6+, Opus 4.6+, Mythos Preview) maps to adaptive thinking, plus `OutputConfig.Effort`. On manual-only models the same fields map to a manual budget. Either way, both happily go on the wire together.

We hit this in `alcova-backend`'s `pkg/forms/analyzer.go`: a thinking-level bump from `Minimal` to `Low` (on the false assumption the call site was on Gemini) flipped the analyzer's per-field LLM calls from "calls the tool" to "returns text only" on Anthropic, and the response loop — which only knows how to read `FunctionCall` parts — failed every field with "no function call found in LLM response" ([Sentry ALCOVA-BACKEND-WM](https://alcova.sentry.io/issues/ALCOVA-BACKEND-WM), [Linear AI-1536](https://linear.app/alcova/issue/AI-1536)).

## Solution

`convertRequest` now clears `params.Thinking` and `params.OutputConfig.Effort` whenever `params.ToolChoice` is forced. The forced `tool_choice` is the load-bearing semantic — the caller has pinned the response shape — so downgrading thinking is the less-surprising correction.

A new exported helper `converters.IsForcedToolUse(tc anthropic.ToolChoiceUnionParam) bool` makes the same check available to callers that want to detect or pre-empt the conflict themselves.

Bumps the changelog to `v0.1.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound API request shaping for a common genai + tools + thinking combo; wrong behavior previously broke forced-tool callers, but the fix alters thinking when tools are pinned and should be verified on real Anthropic traffic.
> 
> **Overview**
> **v0.1.17** works around Anthropic’s incompatibility between **forced** `tool_choice` (`"any"` / `"tool"`) and extended thinking (manual or adaptive). When both would be sent—e.g. `FunctionCallingConfigModeAny` plus adaptive thinking from `ThinkingLevel` or model defaults—`convertRequest` now **clears** `params.Thinking` and `params.OutputConfig.Effort` while **keeping** the forced tool choice, so callers still get a `tool_use` response instead of silent text-only failures.
> 
> Exports **`converters.IsForcedToolUse`** for the same detection outside the adapter. Adds regression tests for forced vs auto/none tool modes across adaptive and manual thinking paths; changelog bumped to v0.1.17.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fee6021bb7b7140e8485923c8a7f832d19ad8e42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->