### PR TITLE
Use GA structured outputs on Vertex AI (AI-1584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Anthropic structured outputs are now GA on Vertex AI (`output_config.format` with a `json_schema`, no beta header), so `convertRequest` sends the real `OutputConfig` schema on the Vertex path — the same GA path the direct API already uses.
 - Removed the prompt-based JSON fallback (`generateWithPromptBasedJSON`, `embedSchemaAsSystemPrompt`, `stripMarkdownFromResponse` and its fence regexes). It embedded the schema in the system prompt and stripped markdown fences from the reply — a workaround that masked regressions and could leave preamble or fenced JSON to crash downstream parsing.
+- Set `additionalProperties: false` on every object node of the output schema. Anthropic structured outputs reject an `object` schema that doesn't explicitly disallow extra properties (`output_config.format.schema: For 'object' type, 'additionalProperties' must be explicitly set to false`), and the genai→JSON-schema conversion didn't emit it.
 - GA structured outputs on Vertex are gated by the org policy `constraints/vertexai.allowedPartnerModelFeatures`, enabled separately. If it isn't enabled, Vertex returns an error rather than silently degrading.
 
 ## [v0.1.17] - Drop thinking under forced tool_choice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [v0.1.18] - GA structured outputs on Vertex AI
 
-- Anthropic structured outputs are now GA on Vertex AI (`output_config.format` with a `json_schema`, no beta header), so `convertRequest` sends the real `OutputConfig` schema on the Vertex path — the same GA path the direct API already uses.
+- Anthropic structured outputs are now GA on Vertex AI (`output_config.format` with a `json_schema`, no beta header), so `convertRequest` sends the real `OutputConfig` schema on the Vertex path — the same GA path the direct API already uses. Object schemas are emitted with `additionalProperties: false` on every node, which Anthropic structured outputs require.
 - Removed the prompt-based JSON fallback (`generateWithPromptBasedJSON`, `embedSchemaAsSystemPrompt`, `stripMarkdownFromResponse` and its fence regexes). It embedded the schema in the system prompt and stripped markdown fences from the reply — a workaround that masked regressions and could leave preamble or fenced JSON to crash downstream parsing.
 - GA structured outputs on Vertex are gated by the org policy `constraints/vertexai.allowedPartnerModelFeatures`, enabled separately. If it isn't enabled, Vertex returns an error rather than silently degrading.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Anthropic structured outputs are now GA on Vertex AI (`output_config.format` with a `json_schema`, no beta header), so `convertRequest` sends the real `OutputConfig` schema on the Vertex path — the same GA path the direct API already uses.
 - Removed the prompt-based JSON fallback (`generateWithPromptBasedJSON`, `embedSchemaAsSystemPrompt`, `stripMarkdownFromResponse` and its fence regexes). It embedded the schema in the system prompt and stripped markdown fences from the reply — a workaround that masked regressions and could leave preamble or fenced JSON to crash downstream parsing.
-- Set `additionalProperties: false` on every object node of the output schema. Anthropic structured outputs reject an `object` schema that doesn't explicitly disallow extra properties (`output_config.format.schema: For 'object' type, 'additionalProperties' must be explicitly set to false`), and the genai→JSON-schema conversion didn't emit it.
 - GA structured outputs on Vertex are gated by the org policy `constraints/vertexai.allowedPartnerModelFeatures`, enabled separately. If it isn't enabled, Vertex returns an error rather than silently degrading.
 
 ## [v0.1.17] - Drop thinking under forced tool_choice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Anthropic structured outputs are now GA on Vertex AI (`output_config.format` with a `json_schema`, no beta header), so `convertRequest` sends the real `OutputConfig` schema on the Vertex path — the same GA path the direct API already uses. Object schemas are emitted with `additionalProperties: false` on every node, which Anthropic structured outputs require.
 - Removed the prompt-based JSON fallback (`generateWithPromptBasedJSON`, `embedSchemaAsSystemPrompt`, `stripMarkdownFromResponse` and its fence regexes). It embedded the schema in the system prompt and stripped markdown fences from the reply — a workaround that masked regressions and could leave preamble or fenced JSON to crash downstream parsing.
+- `IncludeThoughts` no longer enables thinking. In genai it controls whether thought summaries are *returned*, not whether the model thinks — and Anthropic has no equivalent (thinking, once on, always returns blocks). Thinking is now driven solely by `ThinkingBudget` / `ThinkingLevel` and the per-tier default; `IncludeThoughts` is ignored.
 - GA structured outputs on Vertex are gated by the org policy `constraints/vertexai.allowedPartnerModelFeatures`, enabled separately. If it isn't enabled, Vertex returns an error rather than silently degrading.
 
 ## [v0.1.17] - Drop thinking under forced tool_choice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.1.18] - GA structured outputs on Vertex AI
+
+- Anthropic structured outputs are now GA on Vertex AI (`output_config.format` with a `json_schema`, no beta header), so `convertRequest` sends the real `OutputConfig` schema on the Vertex path — the same GA path the direct API already uses.
+- Removed the prompt-based JSON fallback (`generateWithPromptBasedJSON`, `embedSchemaAsSystemPrompt`, `stripMarkdownFromResponse` and its fence regexes). It embedded the schema in the system prompt and stripped markdown fences from the reply — a workaround that masked regressions and could leave preamble or fenced JSON to crash downstream parsing.
+- GA structured outputs on Vertex are gated by the org policy `constraints/vertexai.allowedPartnerModelFeatures`, enabled separately. If it isn't enabled, Vertex returns an error rather than silently degrading.
+
 ## [v0.1.17] - Drop thinking under forced tool_choice
 
 - Anthropic rejects extended thinking (manual or adaptive) when `tool_choice.type` is `"tool"` or `"any"`. Sent together, the API may either return a 400 or — worse — silently produce a text/thinking response with no `tool_use` block, which looks to callers like the model refused to use the tool.

--- a/anthropic.go
+++ b/anthropic.go
@@ -285,6 +285,7 @@ func (m *anthropicModel) convertRequest(req *model.LLMRequest) (anthropic.Messag
 		// no beta header), so the same path serves both variants.
 		if req.Config.ResponseSchema != nil {
 			schemaMap := converters.SchemaToMap(req.Config.ResponseSchema)
+			enforceStrictObjectSchema(schemaMap)
 			params.OutputConfig = anthropic.OutputConfigParam{
 				Format: anthropic.JSONOutputFormatParam{
 					Schema: schemaMap,
@@ -331,6 +332,29 @@ func (m *anthropicModel) convertRequest(req *model.LLMRequest) (anthropic.Messag
 	}
 
 	return params, nil
+}
+
+// enforceStrictObjectSchema recursively sets additionalProperties:false on every
+// object node of a JSON-schema map. Anthropic structured outputs reject an
+// "object" schema that doesn't explicitly disallow additional properties
+// ("output_config.format.schema: For 'object' type, 'additionalProperties' must
+// be explicitly set to false"), and the genai→map conversion doesn't emit it.
+func enforceStrictObjectSchema(node any) {
+	switch n := node.(type) {
+	case map[string]any:
+		if t, ok := n["type"].(string); ok && t == "object" {
+			if _, exists := n["additionalProperties"]; !exists {
+				n["additionalProperties"] = false
+			}
+		}
+		for _, v := range n {
+			enforceStrictObjectSchema(v)
+		}
+	case []any:
+		for _, v := range n {
+			enforceStrictObjectSchema(v)
+		}
+	}
 }
 
 // maybeAppendUserContent ensures the conversation ends with a user message.

--- a/anthropic.go
+++ b/anthropic.go
@@ -350,6 +350,11 @@ func enforceStrictObjectSchema(node any) {
 		for _, v := range n {
 			enforceStrictObjectSchema(v)
 		}
+	case []map[string]any:
+		// SchemaToMap stores anyOf branches as []map[string]any, not []any.
+		for _, v := range n {
+			enforceStrictObjectSchema(v)
+		}
 	case []any:
 		for _, v := range n {
 			enforceStrictObjectSchema(v)

--- a/anthropic.go
+++ b/anthropic.go
@@ -18,10 +18,7 @@ import (
 	"context"
 	"fmt"
 	"iter"
-	"log/slog"
 	"os"
-	"regexp"
-	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -159,11 +156,6 @@ func (m *anthropicModel) GenerateContent(ctx context.Context, req *model.LLMRequ
 
 // generate calls the model synchronously.
 func (m *anthropicModel) generate(ctx context.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
-	// Vertex AI doesn't support OutputConfig — fall back to prompt-based JSON.
-	if m.variant == VariantVertexAI && req.Config != nil && req.Config.ResponseSchema != nil {
-		return m.generateWithPromptBasedJSON(ctx, req)
-	}
-
 	params, err := m.convertRequest(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert request: %w", err)
@@ -178,43 +170,12 @@ func (m *anthropicModel) generate(ctx context.Context, req *model.LLMRequest) (*
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert response: %w", err)
 	}
-
-	return resp, nil
-}
-
-// generateWithPromptBasedJSON falls back to prompt-based JSON for Vertex AI.
-// It embeds the JSON schema in the system instruction and asks the model to respond with valid JSON.
-func (m *anthropicModel) generateWithPromptBasedJSON(ctx context.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
-	req = embedSchemaAsSystemPrompt(req)
-
-	params, err := m.convertRequest(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert request: %w", err)
-	}
-
-	msg, err := m.client.Messages.New(ctx, params)
-	if err != nil {
-		return nil, fmt.Errorf("failed to call model: %w", err)
-	}
-
-	resp, err := converters.MessageToLLMResponse(msg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert response: %w", err)
-	}
-
-	stripMarkdownFromResponse(ctx, resp)
 
 	return resp, nil
 }
 
 // generateStream returns a stream of responses from the model.
 func (m *anthropicModel) generateStream(ctx context.Context, req *model.LLMRequest) iter.Seq2[*model.LLMResponse, error] {
-	// Vertex AI doesn't support OutputConfig — embed schema as a system prompt instead.
-	promptBasedJSON := m.variant == VariantVertexAI && req.Config != nil && req.Config.ResponseSchema != nil
-	if promptBasedJSON {
-		req = embedSchemaAsSystemPrompt(req)
-	}
-
 	return func(yield func(*model.LLMResponse, error) bool) {
 		params, err := m.convertRequest(req)
 		if err != nil {
@@ -263,9 +224,6 @@ func (m *anthropicModel) generateStream(ctx context.Context, req *model.LLMReque
 		if err != nil {
 			yield(nil, fmt.Errorf("failed to convert stream response: %w", err))
 			return
-		}
-		if promptBasedJSON {
-			stripMarkdownFromResponse(ctx, finalResp)
 		}
 		finalResp.TurnComplete = true
 		yield(finalResp, nil)
@@ -322,8 +280,10 @@ func (m *anthropicModel) convertRequest(req *model.LLMRequest) (anthropic.Messag
 			params.ToolChoice = toolChoice
 		}
 
-		// Structured output format (not supported on Vertex AI — handled via prompt-based fallback)
-		if req.Config.ResponseSchema != nil && m.variant != VariantVertexAI {
+		// Structured output format. Anthropic structured outputs are GA on both
+		// the direct API and Vertex AI (output_config.format with a json_schema,
+		// no beta header), so the same path serves both variants.
+		if req.Config.ResponseSchema != nil {
 			schemaMap := converters.SchemaToMap(req.Config.ResponseSchema)
 			params.OutputConfig = anthropic.OutputConfigParam{
 				Format: anthropic.JSONOutputFormatParam{
@@ -385,90 +345,5 @@ func (m *anthropicModel) maybeAppendUserContent(req *model.LLMRequest) {
 	if last := req.Contents[len(req.Contents)-1]; last != nil && last.Role != "user" {
 		req.Contents = append(req.Contents,
 			genai.NewContentFromText("Continue processing previous requests as instructed.", "user"))
-	}
-}
-
-// embedSchemaAsSystemPrompt returns a cloned request with the JSON schema embedded
-// in the system instruction and ResponseSchema cleared. This is the prompt-based
-// fallback for Vertex AI, which doesn't support OutputConfig.
-func embedSchemaAsSystemPrompt(req *model.LLMRequest) *model.LLMRequest {
-	schemaJSON := converters.SchemaToJSONString(req.Config.ResponseSchema)
-
-	jsonInstruction := fmt.Sprintf(`You must respond with valid JSON that conforms to the following JSON schema:
-
-%s
-
-Respond ONLY with the JSON object, no markdown code fences, no explanations.`, schemaJSON)
-
-	// Clone the config to avoid mutating the original request.
-	modifiedConfig := *req.Config
-	if modifiedConfig.SystemInstruction == nil {
-		modifiedConfig.SystemInstruction = &genai.Content{
-			Parts: []*genai.Part{{Text: jsonInstruction}},
-		}
-	} else {
-		existingText := ""
-		for _, part := range modifiedConfig.SystemInstruction.Parts {
-			if part.Text != "" {
-				existingText += part.Text + "\n\n"
-			}
-		}
-		modifiedConfig.SystemInstruction = &genai.Content{
-			Parts: []*genai.Part{{Text: existingText + jsonInstruction}},
-			Role:  modifiedConfig.SystemInstruction.Role,
-		}
-	}
-	modifiedConfig.ResponseSchema = nil
-
-	return &model.LLMRequest{
-		Model:    req.Model,
-		Contents: req.Contents,
-		Config:   &modifiedConfig,
-		Tools:    req.Tools,
-	}
-}
-
-// markdownFenceRegex matches ```json ... ``` or ``` ... ``` code blocks.
-// Uses non-greedy matching to handle the first complete fence block.
-// The (?s) flag enables dotall mode so . matches newlines.
-var markdownFenceRegex = regexp.MustCompile("(?s)^\\s*```(?:json)?\\s*\n?(.*?)\\s*```\\s*$")
-
-// markdownFenceExtractRegex is a more permissive regex that extracts JSON from
-// anywhere in the response, handling cases where the model adds preamble text.
-var markdownFenceExtractRegex = regexp.MustCompile("(?s)```(?:json)?\\s*\n?(\\{.*?\\}|\\[.*?\\])\\s*```")
-
-// stripMarkdownFromResponse removes markdown code fences from text parts in the response.
-// This handles cases where the model wraps JSON in ```json ... ``` despite instructions.
-// It tries two approaches:
-// 1. First, check if the entire text is wrapped in fences (strict match)
-// 2. If not, try to extract a JSON object/array from within fences (permissive match)
-func stripMarkdownFromResponse(ctx context.Context, resp *model.LLMResponse) {
-	if resp == nil || resp.Content == nil || len(resp.Content.Parts) == 0 {
-		return
-	}
-
-	for _, part := range resp.Content.Parts {
-		if part == nil || part.Text == "" {
-			continue
-		}
-
-		original := part.Text
-
-		// First try strict match: entire text is wrapped in fences
-		if matches := markdownFenceRegex.FindStringSubmatch(part.Text); len(matches) > 1 {
-			part.Text = strings.TrimSpace(matches[1])
-			slog.DebugContext(ctx, "stripped markdown fences from JSON response (strict)",
-				"original_length", len(original),
-				"stripped_length", len(part.Text))
-			continue
-		}
-
-		// Fall back to permissive match: extract JSON from within fences
-		if matches := markdownFenceExtractRegex.FindStringSubmatch(part.Text); len(matches) > 1 {
-			part.Text = strings.TrimSpace(matches[1])
-			slog.DebugContext(ctx, "extracted JSON from markdown fences (permissive)",
-				"original_length", len(original),
-				"stripped_length", len(part.Text))
-		}
 	}
 }

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -204,6 +204,55 @@ func assertAdditionalPropertiesFalse(t *testing.T, schema map[string]any, label 
 	}
 }
 
+func TestConvertRequest_OutputConfig_EnforcesAdditionalPropertiesFalse_AnyOf(t *testing.T) {
+	m := &anthropicModel{
+		name:             "claude-haiku-4-5-20251001",
+		variant:          VariantVertexAI,
+		defaultMaxTokens: defaultMaxTokens,
+	}
+
+	// An object branch inside anyOf. SchemaToMap stores anyOf as
+	// []map[string]any, so the enforcement walk must recurse into it.
+	schema := &genai.Schema{
+		Type: genai.TypeObject,
+		Properties: map[string]*genai.Schema{
+			"choice": {
+				AnyOf: []*genai.Schema{
+					{
+						Type:       genai.TypeObject,
+						Properties: map[string]*genai.Schema{"name": {Type: genai.TypeString}},
+					},
+					{Type: genai.TypeString},
+				},
+			},
+		},
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{genai.NewContentFromText("Hello", "user")},
+		Config:   &genai.GenerateContentConfig{ResponseSchema: schema},
+	}
+
+	params, err := m.convertRequest(req)
+	if err != nil {
+		t.Fatalf("convertRequest() error = %v", err)
+	}
+
+	root := params.OutputConfig.Format.Schema
+	if root == nil {
+		t.Fatal("expected OutputConfig schema to be set")
+	}
+
+	props, _ := root["properties"].(map[string]any)
+	choice, _ := props["choice"].(map[string]any)
+	anyOf, ok := choice["anyOf"].([]map[string]any)
+	if !ok {
+		t.Fatalf("choice.anyOf: want []map[string]any, got %T", choice["anyOf"])
+	}
+	// The object branch under anyOf must get additionalProperties:false.
+	assertAdditionalPropertiesFalse(t, anyOf[0], "choice.anyOf[0]")
+}
+
 func TestConvertRequest_DirectAPI_SetsOutputConfig(t *testing.T) {
 	m := &anthropicModel{
 		name:             "claude-haiku-4-5-20251001",

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -15,7 +15,6 @@
 package adkanthropic
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -98,7 +97,7 @@ func TestNewModel_VertexAI_MissingConfig(t *testing.T) {
 	}
 }
 
-func TestConvertRequest_VertexAI_SkipsOutputConfig(t *testing.T) {
+func TestConvertRequest_VertexAI_SetsOutputConfig(t *testing.T) {
 	m := &anthropicModel{
 		name:             "claude-haiku-4-5-20251001",
 		variant:          VariantVertexAI,
@@ -127,9 +126,9 @@ func TestConvertRequest_VertexAI_SkipsOutputConfig(t *testing.T) {
 		t.Fatalf("convertRequest() error = %v", err)
 	}
 
-	// OutputConfig must not be set for Vertex AI
-	if params.OutputConfig.Format.Schema != nil {
-		t.Error("expected OutputConfig to be empty for Vertex AI, but it was set")
+	// Structured outputs are GA on Vertex AI, so OutputConfig must be set.
+	if params.OutputConfig.Format.Schema == nil {
+		t.Error("expected OutputConfig to be set for Vertex AI, but it was empty")
 	}
 }
 
@@ -444,122 +443,3 @@ func TestConvertRequest_AutoToolUseKeepsThinking(t *testing.T) {
 }
 
 func ptrInt32(v int32) *int32 { return &v }
-
-func TestEmbedSchemaAsSystemPrompt(t *testing.T) {
-	schema := &genai.Schema{
-		Type:     genai.TypeObject,
-		Required: []string{"name"},
-		Properties: map[string]*genai.Schema{
-			"name": {Type: genai.TypeString},
-		},
-	}
-
-	t.Run("no_existing_system_instruction", func(t *testing.T) {
-		req := &model.LLMRequest{
-			Contents: []*genai.Content{
-				genai.NewContentFromText("Hello", "user"),
-			},
-			Config: &genai.GenerateContentConfig{
-				ResponseSchema: schema,
-			},
-		}
-
-		modified := embedSchemaAsSystemPrompt(req)
-
-		// ResponseSchema should be cleared
-		if modified.Config.ResponseSchema != nil {
-			t.Error("expected ResponseSchema to be nil in modified request")
-		}
-
-		// Original request should be unchanged
-		if req.Config.ResponseSchema == nil {
-			t.Error("expected original request ResponseSchema to be unchanged")
-		}
-
-		// System instruction should contain the schema
-		if modified.Config.SystemInstruction == nil {
-			t.Fatal("expected SystemInstruction to be set")
-		}
-		text := modified.Config.SystemInstruction.Parts[0].Text
-		if !strings.Contains(text, "JSON schema") {
-			t.Errorf("expected system instruction to contain schema, got: %s", text)
-		}
-	})
-
-	t.Run("with_existing_system_instruction", func(t *testing.T) {
-		req := &model.LLMRequest{
-			Contents: []*genai.Content{
-				genai.NewContentFromText("Hello", "user"),
-			},
-			Config: &genai.GenerateContentConfig{
-				SystemInstruction: &genai.Content{
-					Parts: []*genai.Part{{Text: "You are a helpful assistant."}},
-				},
-				ResponseSchema: schema,
-			},
-		}
-
-		modified := embedSchemaAsSystemPrompt(req)
-
-		text := modified.Config.SystemInstruction.Parts[0].Text
-		if !strings.Contains(text, "You are a helpful assistant.") {
-			t.Error("expected original system instruction to be preserved")
-		}
-		if !strings.Contains(text, "JSON schema") {
-			t.Error("expected schema instruction to be appended")
-		}
-	})
-}
-
-func TestStripMarkdownFromResponse(t *testing.T) {
-	tests := []struct {
-		name     string
-		text     string
-		wantText string
-	}{
-		{
-			name:     "no_fences",
-			text:     `{"name": "test"}`,
-			wantText: `{"name": "test"}`,
-		},
-		{
-			name:     "json_fence",
-			text:     "```json\n{\"name\": \"test\"}\n```",
-			wantText: `{"name": "test"}`,
-		},
-		{
-			name:     "plain_fence",
-			text:     "```\n{\"name\": \"test\"}\n```",
-			wantText: `{"name": "test"}`,
-		},
-		{
-			name:     "fence_with_preamble",
-			text:     "Here is the result:\n```json\n{\"name\": \"test\"}\n```",
-			wantText: `{"name": "test"}`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resp := &model.LLMResponse{
-				Content: &genai.Content{
-					Parts: []*genai.Part{{Text: tt.text}},
-				},
-			}
-
-			stripMarkdownFromResponse(context.Background(), resp)
-
-			got := resp.Content.Parts[0].Text
-			if got != tt.wantText {
-				t.Errorf("stripMarkdownFromResponse() text = %q, want %q", got, tt.wantText)
-			}
-		})
-	}
-}
-
-func TestStripMarkdownFromResponse_NilSafety(t *testing.T) {
-	// Should not panic on nil inputs
-	stripMarkdownFromResponse(context.Background(), nil)
-	stripMarkdownFromResponse(context.Background(), &model.LLMResponse{})
-	stripMarkdownFromResponse(context.Background(), &model.LLMResponse{Content: &genai.Content{}})
-}

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -132,6 +132,78 @@ func TestConvertRequest_VertexAI_SetsOutputConfig(t *testing.T) {
 	}
 }
 
+func TestConvertRequest_OutputConfig_EnforcesAdditionalPropertiesFalse(t *testing.T) {
+	m := &anthropicModel{
+		name:             "claude-haiku-4-5-20251001",
+		variant:          VariantVertexAI,
+		defaultMaxTokens: defaultMaxTokens,
+	}
+
+	// Top-level object, a nested object property, and an array of objects —
+	// every object node must get additionalProperties:false.
+	schema := &genai.Schema{
+		Type:     genai.TypeObject,
+		Required: []string{"person"},
+		Properties: map[string]*genai.Schema{
+			"person": {
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"name": {Type: genai.TypeString},
+				},
+			},
+			"tags": {
+				Type: genai.TypeArray,
+				Items: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"label": {Type: genai.TypeString},
+					},
+				},
+			},
+		},
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{genai.NewContentFromText("Hello", "user")},
+		Config:   &genai.GenerateContentConfig{ResponseSchema: schema},
+	}
+
+	params, err := m.convertRequest(req)
+	if err != nil {
+		t.Fatalf("convertRequest() error = %v", err)
+	}
+
+	root := params.OutputConfig.Format.Schema
+	if root == nil {
+		t.Fatal("expected OutputConfig schema to be set")
+	}
+
+	assertAdditionalPropertiesFalse(t, root, "root")
+
+	props, _ := root["properties"].(map[string]any)
+	person, _ := props["person"].(map[string]any)
+	assertAdditionalPropertiesFalse(t, person, "person")
+
+	tags, _ := props["tags"].(map[string]any)
+	items, _ := tags["items"].(map[string]any)
+	assertAdditionalPropertiesFalse(t, items, "tags.items")
+}
+
+func assertAdditionalPropertiesFalse(t *testing.T, schema map[string]any, label string) {
+	t.Helper()
+	if schema == nil {
+		t.Fatalf("%s: schema missing", label)
+	}
+	v, ok := schema["additionalProperties"]
+	if !ok {
+		t.Errorf("%s: additionalProperties not set (Anthropic structured outputs require it to be false)", label)
+		return
+	}
+	if b, isBool := v.(bool); !isBool || b {
+		t.Errorf("%s: additionalProperties = %v, want false", label, v)
+	}
+}
+
 func TestConvertRequest_DirectAPI_SetsOutputConfig(t *testing.T) {
 	m := &anthropicModel{
 		name:             "claude-haiku-4-5-20251001",

--- a/converters/converters_test.go
+++ b/converters/converters_test.go
@@ -1256,51 +1256,6 @@ func TestToolConfigToToolChoice(t *testing.T) {
 	}
 }
 
-func TestSchemaToJSONString(t *testing.T) {
-	tests := []struct {
-		name     string
-		schema   *genai.Schema
-		contains []string
-	}{
-		{
-			name:     "nil_schema",
-			schema:   nil,
-			contains: []string{"null"},
-		},
-		{
-			name: "simple_object",
-			schema: &genai.Schema{
-				Type: genai.TypeObject,
-				Properties: map[string]*genai.Schema{
-					"name": {Type: genai.TypeString},
-				},
-				Required: []string{"name"},
-			},
-			contains: []string{`"type": "object"`, `"properties"`, `"name"`, `"required"`},
-		},
-		{
-			name: "with_description",
-			schema: &genai.Schema{
-				Type:        genai.TypeString,
-				Description: "A user name",
-			},
-			contains: []string{`"type": "string"`, `"description": "A user name"`},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := converters.SchemaToJSONString(tt.schema)
-
-			for _, want := range tt.contains {
-				if !strings.Contains(result, want) {
-					t.Errorf("SchemaToJSONString() = %q, want to contain %q", result, want)
-				}
-			}
-		})
-	}
-}
-
 func TestUsageToMetadata_CacheTokens(t *testing.T) {
 	t.Run("cache read tokens mapped to CachedContentTokenCount", func(t *testing.T) {
 		usage := anthropic.Usage{

--- a/converters/converters_test.go
+++ b/converters/converters_test.go
@@ -923,9 +923,9 @@ func TestThinkingConfigToAnthropicThinking(t *testing.T) {
 			wantBudget: 8000,
 		},
 		{
-			name:       "IncludeThoughts alone",
-			cfg:        &genai.ThinkingConfig{IncludeThoughts: true},
-			wantBudget: 10000,
+			name:    "IncludeThoughts alone is ignored",
+			cfg:     &genai.ThinkingConfig{IncludeThoughts: true},
+			wantNil: true,
 		},
 		{
 			name:    "unspecified level no budget no include",
@@ -1031,19 +1031,18 @@ func TestThinkingConfigToAnthropic_ModelAware(t *testing.T) {
 			wantBudget: 1024,
 		},
 
-		// IncludeThoughts behaves per model class
+		// IncludeThoughts is ignored — it's an output-visibility flag, not a thinking toggle
 		{
-			name:         "IncludeThoughts on Sonnet 4.6 → adaptive + high effort",
+			name:         "IncludeThoughts ignored on Sonnet 4.6 → adaptive default, no effort",
 			cfg:          &genai.ThinkingConfig{IncludeThoughts: true},
 			model:        anthropic.ModelClaudeSonnet4_6,
 			wantAdaptive: true,
-			wantEffort:   anthropic.OutputConfigEffortHigh,
 		},
 		{
-			name:       "IncludeThoughts on Haiku 4.5 → manual budget 10000",
-			cfg:        &genai.ThinkingConfig{IncludeThoughts: true},
-			model:      anthropic.ModelClaudeHaiku4_5,
-			wantBudget: 10000,
+			name:    "IncludeThoughts ignored on Haiku 4.5 → off",
+			cfg:     &genai.ThinkingConfig{IncludeThoughts: true},
+			model:   anthropic.ModelClaudeHaiku4_5,
+			wantNil: true,
 		},
 
 		// Explicit overrides remain authoritative

--- a/converters/request.go
+++ b/converters/request.go
@@ -402,10 +402,13 @@ type ThinkingMapping struct {
 //  4. ThinkingLevel == Minimal                               → off
 //  5. ThinkingLevel ∈ {Low, Medium, High}, adaptive          → adaptive + effort
 //  6. ThinkingLevel ∈ {Low, Medium, High}, manual-only       → manual budget mapped from level
-//  7. IncludeThoughts, adaptive-capable model                → adaptive + high effort
-//  8. IncludeThoughts, manual-only model                     → manual budget=10000
-//  9. empty cfg (no fields set), adaptive-capable            → adaptive (default effort = high)
-// 10. empty cfg, manual-only                                 → off
+//  7. empty cfg (no fields set), adaptive-capable            → adaptive (default effort = high)
+//  8. empty cfg, manual-only                                 → off
+//
+// IncludeThoughts is ignored: in genai it governs whether thought summaries
+// are returned, not whether the model thinks, and Anthropic returns thinking
+// blocks whenever thinking is on regardless. Thinking is driven solely by
+// ThinkingBudget / ThinkingLevel and the per-tier default.
 func ThinkingConfigToAnthropic(cfg *genai.ThinkingConfig, model anthropic.Model) ThinkingMapping {
 	adaptive := supportsAdaptiveThinking(model)
 
@@ -436,19 +439,11 @@ func ThinkingConfigToAnthropic(cfg *genai.ThinkingConfig, model anthropic.Model)
 		return ThinkingMapping{Thinking: anthropic.ThinkingConfigParamOfEnabled(levelToBudget(cfg.ThinkingLevel))}
 	}
 
-	if cfg.IncludeThoughts {
-		if adaptive {
-			return ThinkingMapping{
-				Thinking: adaptiveThinking(),
-				Effort:   anthropic.OutputConfigEffortHigh,
-			}
-		}
-		return ThinkingMapping{Thinking: anthropic.ThinkingConfigParamOfEnabled(10000)}
-	}
-
-	// Empty cfg (non-nil, no fields set) — same as nil: pick the per-tier
-	// default. Callers who want thinking off on an adaptive-capable model
-	// must say so explicitly via ThinkingLevel: Minimal.
+	// IncludeThoughts is intentionally ignored — see the doc comment above.
+	//
+	// Empty cfg (no fields set, or only IncludeThoughts) — same as nil: pick
+	// the per-tier default. Callers who want thinking off on an adaptive-capable
+	// model must say so explicitly via ThinkingLevel: Minimal.
 	if adaptive {
 		return ThinkingMapping{Thinking: adaptiveThinking()}
 	}
@@ -458,8 +453,8 @@ func ThinkingConfigToAnthropic(cfg *genai.ThinkingConfig, model anthropic.Model)
 // ThinkingConfigToAnthropicThinking returns just the Thinking parameter, for
 // callers that don't have a model handy and don't care about the effort
 // hint. Equivalent to ThinkingConfigToAnthropic(cfg, "").Thinking — empty
-// model means "treat as non-adaptive", so Low/High/IncludeThoughts/explicit
-// ThinkingBudget all keep their v0.1.9 manual-budget mapping.
+// model means "treat as non-adaptive", so Low/High/explicit ThinkingBudget
+// keep their v0.1.9 manual-budget mapping (IncludeThoughts is ignored).
 //
 // One small behaviour shift vs v0.1.9 worth knowing about: ThinkingLevel:
 // Medium previously fell through v0.1.9's switch (which only enumerated

--- a/converters/tools.go
+++ b/converters/tools.go
@@ -15,7 +15,6 @@
 package converters
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -271,17 +270,6 @@ func SchemaToMap(schema *genai.Schema) map[string]any {
 	}
 
 	return result
-}
-
-// SchemaToJSONString converts a genai.Schema to a pretty-printed JSON string.
-// Used for prompt-based JSON output fallback on Vertex AI.
-func SchemaToJSONString(schema *genai.Schema) string {
-	m := SchemaToMap(schema)
-	b, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return "{}"
-	}
-	return string(b)
 }
 
 // toolChoiceKind represents the resolved tool choice type.


### PR DESCRIPTION
## Problem
On the Vertex path, structured-output requests degraded to prompt-based JSON: for `VariantVertexAI` the schema was embedded in the system prompt and `ResponseSchema` cleared, with a comment that "Vertex AI doesn't support OutputConfig." So Claude-on-Vertex wasn't constrained to emit bare JSON and sometimes returned markdown-fenced JSON or a preamble, which crashed downstream parsing.

Anthropic structured outputs are now GA on Vertex (`output_config.format`, `json_schema`, no beta header), so the workaround is obsolete.

## Solution
- Send the real `output_config` schema on the Vertex path — drop the `m.variant != VariantVertexAI` exclusion in `convertRequest` so Vertex uses the same GA structured-output path as the direct API.
- Remove the prompt-based fallback entirely (`generateWithPromptBasedJSON`, `embedSchemaAsSystemPrompt`, `stripMarkdownFromResponse` and its fence regexes). It's now dead code, and a silent fallback would mask regressions.
- Tests: the Vertex path now asserts the schema is set (mirroring the direct-API test); fallback tests removed.

Merging auto-tags `v0.1.18`; the alcova-backend `go.mod` bump is a follow-up once tagged.

Note: GA structured outputs on Vertex are gated by the org policy `constraints/vertexai.allowedPartnerModelFeatures`, enabled separately. If it isn't enabled, Vertex returns an error rather than degrading — the correct, visible failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Vertex structured-output behavior changes materially (no silent fallback); deployments without the Vertex partner-model feature policy will see API errors instead of degraded JSON. IncludeThoughts stops enabling thinking, which may surprise callers relying on the old mapping.
> 
> **Overview**
> Vertex AI now uses the same GA **structured outputs** path as the direct API: `convertRequest` always sets `OutputConfig` from `ResponseSchema` when present, instead of skipping it on Vertex and falling back to embedding the schema in the system prompt.
> 
> The **prompt-based JSON workaround** is removed end-to-end (`generateWithPromptBasedJSON`, schema-in-system-prompt cloning, markdown fence stripping, and `SchemaToJSONString`). Sync and streaming both go through a single `convertRequest` → API call path.
> 
> Before sending schemas, **`enforceStrictObjectSchema`** walks the converted map and sets `additionalProperties: false` on every `object` node (including nested properties and `anyOf` branches), matching Anthropic’s structured-output requirement.
> 
> **`IncludeThoughts`** no longer turns on extended thinking in `ThinkingConfigToAnthropic`; only `ThinkingBudget`, `ThinkingLevel`, and model-tier defaults apply. Tests and changelog document v0.1.18, including that Vertex GA structured outputs depend on org policy `constraints/vertexai.allowedPartnerModelFeatures` (failure is an API error, not a silent fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72cd32dfba8ae4435d4edc199a04c1aace0d6e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->