### PR TITLE
Preserve thinking blocks across consecutive assistant turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v2.0.1] - Preserve thinking blocks across assistant turns
+
+- Prevent Anthropic 400 errors when ADK history contains consecutive assistant turns by keeping signed and redacted thinking blocks immutable and inserting synthetic user continuation boundaries instead of merging protected messages.
+- Preserve empty and redacted thinking through persisted history, and reject malformed signatures or unresolved tool-use histories before sending an invalid request.
+
 ## [v2.0.0] - Migrate to adk-go v2
 
 - Upgrade `google.golang.org/adk` to `google.golang.org/adk/v2` v2.0.0 — module path changes to `github.com/Alcova-AI/adk-anthropic-go/v2` per Go's semantic import versioning rules for major version 2+.

--- a/converters/converters_test.go
+++ b/converters/converters_test.go
@@ -15,6 +15,7 @@
 package converters_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -69,7 +70,7 @@ func TestContentsToMessages_MultiTurn(t *testing.T) {
 	}
 }
 
-func TestContentsToMessages_MergesConsecutiveRoles(t *testing.T) {
+func TestContentsToMessages_MergesConsecutiveUserMessages(t *testing.T) {
 	contents := []*genai.Content{
 		genai.NewContentFromText("Hello", "user"),
 		genai.NewContentFromText("How are you?", "user"),
@@ -88,6 +89,299 @@ func TestContentsToMessages_MergesConsecutiveRoles(t *testing.T) {
 	// Should have 2 content blocks
 	if len(messages[0].Content) != 2 {
 		t.Errorf("expected 2 content blocks, got %d", len(messages[0].Content))
+	}
+}
+
+func TestContentsToMessages_MergesConsecutiveAssistantMessagesWithoutThinking(t *testing.T) {
+	contents := []*genai.Content{
+		genai.NewContentFromText("First response", "model"),
+		genai.NewContentFromText("Second response", "model"),
+	}
+
+	messages, err := converters.ContentsToMessages(contents)
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 merged message, got %d", len(messages))
+	}
+	if messages[0].Role != anthropic.MessageParamRoleAssistant {
+		t.Errorf("role = %q, want %q", messages[0].Role, anthropic.MessageParamRoleAssistant)
+	}
+	if len(messages[0].Content) != 2 {
+		t.Errorf("expected 2 content blocks, got %d", len(messages[0].Content))
+	}
+}
+
+func TestContentsToMessages_PreservesBoundaryWhenEitherAssistantMessageHasThinking(t *testing.T) {
+	thought := &genai.Part{
+		Text:             "Signed thought",
+		Thought:          true,
+		ThoughtSignature: []byte("signature"),
+	}
+	emptyThought := &genai.Part{
+		Thought:          true,
+		ThoughtSignature: []byte("signature"),
+	}
+	plain := &genai.Part{Text: "Plain response"}
+	tests := []struct {
+		name  string
+		parts []*genai.Part
+	}{
+		{name: "thinking then plain", parts: []*genai.Part{thought, plain}},
+		{name: "plain then thinking", parts: []*genai.Part{plain, thought}},
+		{name: "empty thinking then plain", parts: []*genai.Part{emptyThought, plain}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages, err := converters.ContentsToMessages([]*genai.Content{
+				{Role: "model", Parts: []*genai.Part{tt.parts[0]}},
+				{Role: "model", Parts: []*genai.Part{tt.parts[1]}},
+			})
+			if err != nil {
+				t.Fatalf("ContentsToMessages() error = %v", err)
+			}
+
+			wantRoles := []anthropic.MessageParamRole{
+				anthropic.MessageParamRoleAssistant,
+				anthropic.MessageParamRoleUser,
+				anthropic.MessageParamRoleAssistant,
+			}
+			if len(messages) != len(wantRoles) {
+				t.Fatalf("expected %d messages, got %d", len(wantRoles), len(messages))
+			}
+			for i, wantRole := range wantRoles {
+				if messages[i].Role != wantRole {
+					t.Errorf("message %d: role = %q, want %q", i, messages[i].Role, wantRole)
+				}
+			}
+		})
+	}
+}
+
+func TestContentsToMessages_PreservesRedactedThinkingBoundary(t *testing.T) {
+	var responseBlock anthropic.ContentBlockUnion
+	if err := responseBlock.UnmarshalJSON([]byte(`{
+		"type": "redacted_thinking",
+		"data": "opaque-redacted-data"
+	}`)); err != nil {
+		t.Fatalf("failed to unmarshal redacted thinking block: %v", err)
+	}
+
+	redactedPart, err := converters.ContentBlockToGenaiPart(responseBlock)
+	if err != nil {
+		t.Fatalf("ContentBlockToGenaiPart() error = %v", err)
+	}
+	partJSON, err := json.Marshal(redactedPart)
+	if err != nil {
+		t.Fatalf("failed to marshal redacted thinking part: %v", err)
+	}
+	var persistedPart genai.Part
+	if err := json.Unmarshal(partJSON, &persistedPart); err != nil {
+		t.Fatalf("failed to unmarshal redacted thinking part: %v", err)
+	}
+	messages, err := converters.ContentsToMessages([]*genai.Content{
+		{Role: "model", Parts: []*genai.Part{&persistedPart}},
+		genai.NewContentFromText("Plain response", "model"),
+	})
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+
+	wantRoles := []anthropic.MessageParamRole{
+		anthropic.MessageParamRoleAssistant,
+		anthropic.MessageParamRoleUser,
+		anthropic.MessageParamRoleAssistant,
+	}
+	if len(messages) != len(wantRoles) {
+		t.Fatalf("expected %d messages, got %d", len(wantRoles), len(messages))
+	}
+	for i, wantRole := range wantRoles {
+		if messages[i].Role != wantRole {
+			t.Errorf("message %d: role = %q, want %q", i, messages[i].Role, wantRole)
+		}
+	}
+
+	redactedThinking := messages[0].Content[0].OfRedactedThinking
+	if redactedThinking == nil {
+		t.Fatal("first assistant message does not contain redacted thinking")
+	}
+	if redactedThinking.Data != "opaque-redacted-data" {
+		t.Errorf("redacted thinking data = %q, want %q", redactedThinking.Data, "opaque-redacted-data")
+	}
+}
+
+func TestThinkingBlock_RoundTripsThroughPersistedPart(t *testing.T) {
+	var responseBlock anthropic.ContentBlockUnion
+	if err := responseBlock.UnmarshalJSON([]byte(`{
+		"type": "thinking",
+		"thinking": "",
+		"signature": "c2lnbmF0dXJl"
+	}`)); err != nil {
+		t.Fatalf("failed to unmarshal thinking block: %v", err)
+	}
+
+	part, err := converters.ContentBlockToGenaiPart(responseBlock)
+	if err != nil {
+		t.Fatalf("ContentBlockToGenaiPart() error = %v", err)
+	}
+	partJSON, err := json.Marshal(part)
+	if err != nil {
+		t.Fatalf("failed to marshal thinking part: %v", err)
+	}
+	var persistedPart genai.Part
+	if err := json.Unmarshal(partJSON, &persistedPart); err != nil {
+		t.Fatalf("failed to unmarshal thinking part: %v", err)
+	}
+
+	requestBlock, err := converters.PartToContentBlock(&persistedPart)
+	if err != nil {
+		t.Fatalf("PartToContentBlock() error = %v", err)
+	}
+	if requestBlock == nil || requestBlock.OfThinking == nil {
+		t.Fatal("persisted part did not round-trip to a thinking block")
+	}
+	if requestBlock.OfThinking.Thinking != "" {
+		t.Errorf("thinking text = %q, want empty text", requestBlock.OfThinking.Thinking)
+	}
+	if requestBlock.OfThinking.Signature != "c2lnbmF0dXJl" {
+		t.Errorf("thinking signature = %q, want %q", requestBlock.OfThinking.Signature, "c2lnbmF0dXJl")
+	}
+}
+
+func TestContentsToMessages_RejectsThinkingBoundaryAfterToolUse(t *testing.T) {
+	_, err := converters.ContentsToMessages([]*genai.Content{
+		{
+			Role: "model",
+			Parts: []*genai.Part{
+				{Text: "Signed thought", Thought: true, ThoughtSignature: []byte("signature")},
+				{FunctionCall: &genai.FunctionCall{ID: "toolu_123", Name: "edit_document"}},
+			},
+		},
+		{
+			Role: "model",
+			Parts: []*genai.Part{
+				{Text: "Another thought", Thought: true, ThoughtSignature: []byte("signature-2")},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected missing tool result to return an error")
+	}
+	if !strings.Contains(err.Error(), "without an intervening tool result") {
+		t.Errorf("error = %q, want missing tool result context", err)
+	}
+}
+
+func TestContentBlockToGenaiPart_RejectsInvalidThinkingSignature(t *testing.T) {
+	var responseBlock anthropic.ContentBlockUnion
+	if err := responseBlock.UnmarshalJSON([]byte(`{
+		"type": "thinking",
+		"thinking": "Signed thought",
+		"signature": "not-valid-base64"
+	}`)); err != nil {
+		t.Fatalf("failed to unmarshal thinking block: %v", err)
+	}
+
+	_, err := converters.ContentBlockToGenaiPart(responseBlock)
+	if err == nil {
+		t.Fatal("expected invalid thinking signature to return an error")
+	}
+	if !strings.Contains(err.Error(), "failed to decode thinking signature") {
+		t.Errorf("error = %q, want thinking signature context", err)
+	}
+}
+
+func TestContentsToMessages_PreservesConsecutiveSignedThinkingMessages(t *testing.T) {
+	firstSignature := []byte("first-signature")
+	secondSignature := []byte("second-signature")
+	contents := []*genai.Content{
+		genai.NewContentFromText("Start", "user"),
+		{
+			Role: "model",
+			Parts: []*genai.Part{
+				{Text: "First thought", Thought: true, ThoughtSignature: firstSignature},
+			},
+		},
+		{
+			Role: "model",
+			Parts: []*genai.Part{
+				{Text: "Second thought", Thought: true, ThoughtSignature: secondSignature},
+				{FunctionCall: &genai.FunctionCall{
+					ID:   "toolu_123",
+					Name: "edit_document",
+					Args: map[string]any{"path": "report.docx"},
+				}},
+			},
+		},
+	}
+
+	messages, err := converters.ContentsToMessages(contents)
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+
+	wantRoles := []anthropic.MessageParamRole{
+		anthropic.MessageParamRoleUser,
+		anthropic.MessageParamRoleAssistant,
+		anthropic.MessageParamRoleUser,
+		anthropic.MessageParamRoleAssistant,
+	}
+	if len(messages) != len(wantRoles) {
+		t.Fatalf("expected %d messages, got %d", len(wantRoles), len(messages))
+	}
+	for i, wantRole := range wantRoles {
+		if messages[i].Role != wantRole {
+			t.Errorf("message %d: role = %q, want %q", i, messages[i].Role, wantRole)
+		}
+	}
+	if len(messages[2].Content) != 1 || messages[2].Content[0].OfText == nil {
+		t.Fatal("inserted user continuation does not contain exactly one text block")
+	}
+	wantContinuation := "Continue processing previous requests as instructed. Exit or provide a summary if no more outputs are needed."
+	if messages[2].Content[0].OfText.Text != wantContinuation {
+		t.Errorf("continuation text = %q, want %q", messages[2].Content[0].OfText.Text, wantContinuation)
+	}
+
+	if len(messages[1].Content) != 1 {
+		t.Fatalf("first assistant message has %d blocks, want 1", len(messages[1].Content))
+	}
+	firstThinking := messages[1].Content[0].OfThinking
+	if firstThinking == nil {
+		t.Fatal("first assistant message does not contain a thinking block")
+	}
+	if firstThinking.Thinking != "First thought" {
+		t.Errorf("first thinking text = %q, want %q", firstThinking.Thinking, "First thought")
+	}
+	if firstThinking.Signature != "Zmlyc3Qtc2lnbmF0dXJl" {
+		t.Errorf("first thinking signature = %q, want original base64 signature", firstThinking.Signature)
+	}
+
+	if len(messages[3].Content) != 2 {
+		t.Fatalf("second assistant message has %d blocks, want 2", len(messages[3].Content))
+	}
+	secondThinking := messages[3].Content[0].OfThinking
+	if secondThinking == nil {
+		t.Fatal("second assistant message does not contain a thinking block")
+	}
+	if secondThinking.Thinking != "Second thought" {
+		t.Errorf("second thinking text = %q, want %q", secondThinking.Thinking, "Second thought")
+	}
+	if secondThinking.Signature != "c2Vjb25kLXNpZ25hdHVyZQ==" {
+		t.Errorf("second thinking signature = %q, want original base64 signature", secondThinking.Signature)
+	}
+
+	toolUse := messages[3].Content[1].OfToolUse
+	if toolUse == nil {
+		t.Fatal("second assistant message does not contain the original tool use")
+	}
+	if toolUse.ID != "toolu_123" || toolUse.Name != "edit_document" {
+		t.Errorf("tool use = (%q, %q), want (%q, %q)", toolUse.ID, toolUse.Name, "toolu_123", "edit_document")
+	}
+	if diff := cmp.Diff(map[string]any{"path": "report.docx"}, toolUse.Input); diff != "" {
+		t.Errorf("tool input mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/converters/request.go
+++ b/converters/request.go
@@ -25,8 +25,15 @@ import (
 	"google.golang.org/genai"
 )
 
-// ContentsToMessages converts genai Contents to Anthropic MessageParams.
-// It handles role mapping and content part conversion.
+const (
+	continuationPrompt              = "Continue processing previous requests as instructed. Exit or provide a summary if no more outputs are needed."
+	redactedThinkingDataMetadataKey = "anthropic.redacted_thinking_data"
+)
+
+// ContentsToMessages converts genai Contents to Anthropic MessageParams. It
+// merges ordinary same-role turns, but inserts a synthetic user continuation
+// between assistant turns when merging would modify a thinking block. It
+// returns an error when an unresolved tool use prevents inserting that boundary.
 func ContentsToMessages(contents []*genai.Content) ([]anthropic.MessageParam, error) {
 	if len(contents) == 0 {
 		return nil, nil
@@ -47,8 +54,12 @@ func ContentsToMessages(contents []*genai.Content) ([]anthropic.MessageParam, er
 		}
 	}
 
-	// Merge consecutive messages with the same role (Anthropic requires alternating roles)
-	messages = mergeConsecutiveMessages(messages)
+	// Anthropic combines consecutive messages with the same role. Normalise them
+	// explicitly so signed thinking blocks retain their original message boundary.
+	messages, err := normalizeConsecutiveMessages(messages)
+	if err != nil {
+		return nil, fmt.Errorf("failed to normalize messages: %w", err)
+	}
 
 	return messages, nil
 }
@@ -133,22 +144,23 @@ func PartToContentBlock(part *genai.Part) (*anthropic.ContentBlockParamUnion, er
 		return nil, nil
 	}
 
+	if data, ok := redactedThinkingData(part); ok {
+		block := anthropic.NewRedactedThinkingBlock(data)
+		return &block, nil
+	}
+
+	// Thoughts from model responses must be passed back with their signature,
+	// including when Anthropic returned an empty thinking summary.
+	if part.Thought && len(part.ThoughtSignature) > 0 {
+		block := anthropic.NewThinkingBlock(
+			base64.StdEncoding.EncodeToString(part.ThoughtSignature),
+			part.Text,
+		)
+		return &block, nil
+	}
+
 	// Text content
 	if part.Text != "" {
-		// Check if this is a thought block
-		if part.Thought {
-			// Thoughts from model responses need to be passed back with signature
-			if len(part.ThoughtSignature) > 0 {
-				block := anthropic.ContentBlockParamUnion{
-					OfThinking: &anthropic.ThinkingBlockParam{
-						Thinking:  part.Text,
-						Signature: base64.StdEncoding.EncodeToString(part.ThoughtSignature),
-					},
-				}
-				return &block, nil
-			}
-			// If no signature, treat as regular text (shouldn't happen in valid flow)
-		}
 		block := anthropic.NewTextBlock(part.Text)
 		return &block, nil
 	}
@@ -181,6 +193,14 @@ func PartToContentBlock(part *genai.Part) (*anthropic.ContentBlockParamUnion, er
 	}
 
 	return nil, nil
+}
+
+func redactedThinkingData(part *genai.Part) (string, bool) {
+	if !part.Thought || part.PartMetadata == nil {
+		return "", false
+	}
+	data, ok := part.PartMetadata[redactedThinkingDataMetadataKey].(string)
+	return data, ok
 }
 
 // inlineDataToBlock converts inline binary data to an Anthropic content block.
@@ -343,29 +363,60 @@ func SystemInstructionToSystem(instruction *genai.Content) []anthropic.TextBlock
 	return blocks
 }
 
-// mergeConsecutiveMessages merges consecutive messages with the same role.
-// Anthropic requires strictly alternating user/assistant messages.
-func mergeConsecutiveMessages(messages []anthropic.MessageParam) []anthropic.MessageParam {
+// normalizeConsecutiveMessages makes roles alternate without modifying
+// thinking-bearing messages. Anthropic rejects signed thinking blocks when
+// their original assistant message is changed, including by combining it with
+// an adjacent assistant message.
+func normalizeConsecutiveMessages(messages []anthropic.MessageParam) ([]anthropic.MessageParam, error) {
 	if len(messages) <= 1 {
-		return messages
+		return messages, nil
 	}
 
-	var merged []anthropic.MessageParam
+	var normalized []anthropic.MessageParam
 	for i, msg := range messages {
 		if i == 0 {
-			merged = append(merged, msg)
+			normalized = append(normalized, msg)
 			continue
 		}
 
-		last := &merged[len(merged)-1]
-		if last.Role == msg.Role {
-			// Merge content blocks
-			last.Content = append(last.Content, msg.Content...)
+		last := &normalized[len(normalized)-1]
+		if last.Role != msg.Role {
+			normalized = append(normalized, msg)
+			continue
+		}
+
+		if msg.Role == anthropic.MessageParamRoleAssistant &&
+			(hasThinkingBlock(last.Content) || hasThinkingBlock(msg.Content)) {
+			if hasToolUseBlock(last.Content) {
+				return nil, fmt.Errorf("cannot preserve thinking boundary after tool use without an intervening tool result")
+			}
+			normalized = append(normalized,
+				anthropic.NewUserMessage(anthropic.NewTextBlock(continuationPrompt)),
+				msg,
+			)
 		} else {
-			merged = append(merged, msg)
+			last.Content = append(last.Content, msg.Content...)
 		}
 	}
-	return merged
+	return normalized, nil
+}
+
+func hasThinkingBlock(blocks []anthropic.ContentBlockParamUnion) bool {
+	for _, block := range blocks {
+		if block.OfThinking != nil || block.OfRedactedThinking != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasToolUseBlock(blocks []anthropic.ContentBlockParamUnion) bool {
+	for _, block := range blocks {
+		if block.OfToolUse != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // ThinkingMapping bundles the Anthropic thinking parameter and the optional

--- a/converters/response.go
+++ b/converters/response.go
@@ -75,7 +75,10 @@ func ContentBlockToGenaiPart(block anthropic.ContentBlockUnion) (*genai.Part, er
 
 	case anthropic.ThinkingBlock:
 		// Map thinking blocks to genai.Part with Thought=true
-		signature, _ := base64.StdEncoding.DecodeString(variant.Signature)
+		signature, err := base64.StdEncoding.DecodeString(variant.Signature)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode thinking signature: %w", err)
+		}
 		return &genai.Part{
 			Text:             variant.Thinking,
 			Thought:          true,
@@ -83,10 +86,14 @@ func ContentBlockToGenaiPart(block anthropic.ContentBlockUnion) (*genai.Part, er
 		}, nil
 
 	case anthropic.RedactedThinkingBlock:
-		// Redacted thinking - we can't see the content but preserve the marker
+		// Keep the opaque data in provider-scoped metadata so the exact redacted
+		// block can be passed back while retaining a useful display marker.
 		return &genai.Part{
 			Text:    "[thinking redacted]",
 			Thought: true,
+			PartMetadata: map[string]any{
+				redactedThinkingDataMetadataKey: variant.Data,
+			},
 		}, nil
 
 	case anthropic.ToolUseBlock:


### PR DESCRIPTION
## Problem

ADK can produce consecutive assistant events when a thought-only response is followed by a continued model response. The adapter currently combines same-role messages before sending them to Anthropic. The combined message no longer matches the original assistant message that owns each signed thinking block. Anthropic rejects it with HTTP 400, and later turns replaying that history fail immediately.

## Change

Preserves assistant message boundaries when either adjacent message contains thinking. The adapter inserts the same synthetic user continuation used by ADK, keeping roles alternating without changing thinking text, signatures, redacted data, or tool calls. Ordinary consecutive user and assistant messages continue to merge.

Preserves empty and redacted thinking through the Anthropic response, persisted `genai.Part`, and Anthropic request round trip. Invalid signatures and histories with an unresolved tool use now return conversion errors instead of emitting malformed history.

## Design

- Keeps boundary normalization in the adapter rather than session persistence: Anthropic's message protocol owns the alternation and signed-block invariants
- Stores opaque redacted-thinking data in provider-scoped part metadata rather than `ThoughtSignature`: the two payloads retain distinct meanings and both survive JSON persistence
