### PR TITLE
Fix structured schemas and thinking display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v2.0.2] - Normalize structured schemas and thinking display
+
+- Transform response schemas through Anthropic's compatibility rules before sending `output_config`, including moving unsupported constraints into descriptions and enforcing `additionalProperties: false` recursively.
+- Map `IncludeThoughts` to Anthropic's thinking `display`: return summarized thoughts only when requested, otherwise omit their text while preserving signed thinking continuity.
+
 ## [v2.0.1] - Preserve thinking blocks across assistant turns
 
 - Prevent Anthropic 400 errors when ADK history contains consecutive assistant turns by keeping signed and redacted thinking blocks immutable and inserting synthetic user continuation boundaries instead of merging protected messages.

--- a/README.md
+++ b/README.md
@@ -166,12 +166,14 @@ Mode mapping:
 
 ### Extended Thinking (ThinkingConfig)
 
-Use `ThinkingConfig` to enable extended thinking:
+Use `ThinkingConfig` to control extended thinking. Set `IncludeThoughts` when
+you also want summarized thinking text returned in the response:
 
 ```go
 config := &genai.GenerateContentConfig{
 	ThinkingConfig: &genai.ThinkingConfig{
-		ThinkingLevel: genai.ThinkingLevelHigh,
+		ThinkingLevel:  genai.ThinkingLevelHigh,
+		IncludeThoughts: true,
 	},
 }
 ```
@@ -189,12 +191,18 @@ config := &genai.GenerateContentConfig{
 Mapping:
 | `genai` ThinkingConfig | Anthropic Behavior |
 |---|---|
-| `ThinkingLevel: HIGH` | Thinking enabled, 10,000 token budget |
-| `ThinkingLevel: LOW` | Thinking enabled, 1,024 token budget (minimum) |
-| `ThinkingBudget` set | Thinking enabled with the exact budget (overrides level defaults) |
-| `IncludeThoughts: true` (no level/budget) | Thinking enabled, 10,000 token budget |
+| `ThinkingLevel: HIGH` | Adaptive thinking with high effort on supported models; otherwise manual thinking with a 10,000-token budget |
+| `ThinkingLevel: MEDIUM` | Adaptive thinking with medium effort on supported models; otherwise manual thinking with a 5,000-token budget |
+| `ThinkingLevel: LOW` | Adaptive thinking with low effort on supported models; otherwise manual thinking with the minimum 1,024-token budget |
+| `ThinkingLevel: MINIMAL` | Thinking disabled |
+| `ThinkingBudget` set | Manual thinking with the exact budget, overriding `ThinkingLevel` |
+| `IncludeThoughts: true` | Return summarized thinking text when thinking is enabled; does not enable thinking |
+| `IncludeThoughts: false` or unset | Omit thinking text while preserving its signature for multi-turn continuity; does not disable thinking |
+| Nil or otherwise empty config | Adaptive thinking with the provider's default effort on supported models; thinking disabled on manual-only models |
 
-Thinking blocks in responses are mapped to `genai.Part` with `Thought=true` and `ThoughtSignature` preserved for multi-turn conversations.
+Thinking blocks in responses are mapped to `genai.Part` with `Thought=true` and
+`ThoughtSignature` preserved for multi-turn conversations. When thoughts are
+omitted, the part has empty text but retains its signature.
 
 ## License
 

--- a/anthropic.go
+++ b/anthropic.go
@@ -284,8 +284,10 @@ func (m *anthropicModel) convertRequest(req *model.LLMRequest) (anthropic.Messag
 		// the direct API and Vertex AI (output_config.format with a json_schema,
 		// no beta header), so the same path serves both variants.
 		if req.Config.ResponseSchema != nil {
-			schemaMap := converters.SchemaToMap(req.Config.ResponseSchema)
-			enforceStrictObjectSchema(schemaMap)
+			schemaMap, err := converters.SchemaToStructuredOutputMap(req.Config.ResponseSchema)
+			if err != nil {
+				return anthropic.MessageNewParams{}, fmt.Errorf("failed to transform response schema: %w", err)
+			}
 			params.OutputConfig = anthropic.OutputConfigParam{
 				Format: anthropic.JSONOutputFormatParam{
 					Schema: schemaMap,
@@ -332,34 +334,6 @@ func (m *anthropicModel) convertRequest(req *model.LLMRequest) (anthropic.Messag
 	}
 
 	return params, nil
-}
-
-// enforceStrictObjectSchema recursively sets additionalProperties:false on every
-// object node of a JSON-schema map. Anthropic structured outputs reject an
-// "object" schema that doesn't explicitly disallow additional properties
-// ("output_config.format.schema: For 'object' type, 'additionalProperties' must
-// be explicitly set to false"), and the genai→map conversion doesn't emit it.
-func enforceStrictObjectSchema(node any) {
-	switch n := node.(type) {
-	case map[string]any:
-		if t, ok := n["type"].(string); ok && t == "object" {
-			if _, exists := n["additionalProperties"]; !exists {
-				n["additionalProperties"] = false
-			}
-		}
-		for _, v := range n {
-			enforceStrictObjectSchema(v)
-		}
-	case []map[string]any:
-		// SchemaToMap stores anyOf branches as []map[string]any, not []any.
-		for _, v := range n {
-			enforceStrictObjectSchema(v)
-		}
-	case []any:
-		for _, v := range n {
-			enforceStrictObjectSchema(v)
-		}
-	}
 }
 
 // maybeAppendUserContent ensures the conversation ends with a user message.

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -189,6 +189,95 @@ func TestConvertRequest_OutputConfig_EnforcesAdditionalPropertiesFalse(t *testin
 	assertAdditionalPropertiesFalse(t, items, "tags.items")
 }
 
+func TestConvertRequest_VertexAI_TransformsUnsupportedSchemaConstraints(t *testing.T) {
+	m := &anthropicModel{
+		name:             "claude-haiku-4-5-20251001",
+		variant:          VariantVertexAI,
+		defaultMaxTokens: defaultMaxTokens,
+	}
+
+	minimum, maximum := 1.0, 100.0
+	minLength, maxLength := int64(2), int64(50)
+	minItems, maxItems := int64(2), int64(20)
+	schema := &genai.Schema{
+		Type: genai.TypeObject,
+		Properties: map[string]*genai.Schema{
+			"score": {
+				Type:        genai.TypeNumber,
+				Description: "A score",
+				Minimum:     &minimum,
+				Maximum:     &maximum,
+			},
+			"name": {
+				Type:      genai.TypeString,
+				MinLength: &minLength,
+				MaxLength: &maxLength,
+			},
+			"tags": {
+				Type:     genai.TypeArray,
+				Items:    &genai.Schema{Type: genai.TypeString},
+				MinItems: &minItems,
+				MaxItems: &maxItems,
+			},
+		},
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{genai.NewContentFromText("Hello", "user")},
+		Config:   &genai.GenerateContentConfig{ResponseSchema: schema},
+	}
+
+	params, err := m.convertRequest(req)
+	if err != nil {
+		t.Fatalf("convertRequest() error = %v", err)
+	}
+
+	root := params.OutputConfig.Format.Schema
+	properties, ok := root["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties = %T, want map[string]any", root["properties"])
+	}
+
+	score, ok := properties["score"].(map[string]any)
+	if !ok {
+		t.Fatalf("score = %T, want map[string]any", properties["score"])
+	}
+	for _, unsupported := range []string{"minimum", "maximum"} {
+		if _, exists := score[unsupported]; exists {
+			t.Errorf("score.%s should be removed from the Anthropic schema", unsupported)
+		}
+	}
+	if description, _ := score["description"].(string); !strings.Contains(description, "maximum: 100") || !strings.Contains(description, "minimum: 1") {
+		t.Errorf("score.description = %q, want preserved minimum and maximum guidance", description)
+	}
+
+	name, ok := properties["name"].(map[string]any)
+	if !ok {
+		t.Fatalf("name = %T, want map[string]any", properties["name"])
+	}
+	for _, unsupported := range []string{"minLength", "maxLength"} {
+		if _, exists := name[unsupported]; exists {
+			t.Errorf("name.%s should be removed from the Anthropic schema", unsupported)
+		}
+	}
+	if description, _ := name["description"].(string); !strings.Contains(description, "maxLength: 50") || !strings.Contains(description, "minLength: 2") {
+		t.Errorf("name.description = %q, want preserved length guidance", description)
+	}
+
+	tags, ok := properties["tags"].(map[string]any)
+	if !ok {
+		t.Fatalf("tags = %T, want map[string]any", properties["tags"])
+	}
+	for _, unsupported := range []string{"minItems", "maxItems"} {
+		if _, exists := tags[unsupported]; exists {
+			t.Errorf("tags.%s should be removed from the Anthropic schema", unsupported)
+		}
+	}
+	if description, _ := tags["description"].(string); !strings.Contains(description, "maxItems: 20") || !strings.Contains(description, "minItems: 2") {
+		t.Errorf("tags.description = %q, want preserved item-count guidance", description)
+	}
+}
+
 func assertAdditionalPropertiesFalse(t *testing.T, schema map[string]any, label string) {
 	t.Helper()
 	if schema == nil {
@@ -245,12 +334,16 @@ func TestConvertRequest_OutputConfig_EnforcesAdditionalPropertiesFalse_AnyOf(t *
 
 	props, _ := root["properties"].(map[string]any)
 	choice, _ := props["choice"].(map[string]any)
-	anyOf, ok := choice["anyOf"].([]map[string]any)
+	anyOf, ok := choice["anyOf"].([]any)
 	if !ok {
-		t.Fatalf("choice.anyOf: want []map[string]any, got %T", choice["anyOf"])
+		t.Fatalf("choice.anyOf: want []any, got %T", choice["anyOf"])
+	}
+	objectBranch, ok := anyOf[0].(map[string]any)
+	if !ok {
+		t.Fatalf("choice.anyOf[0]: want map[string]any, got %T", anyOf[0])
 	}
 	// The object branch under anyOf must get additionalProperties:false.
-	assertAdditionalPropertiesFalse(t, anyOf[0], "choice.anyOf[0]")
+	assertAdditionalPropertiesFalse(t, objectBranch, "choice.anyOf[0]")
 }
 
 func TestConvertRequest_DirectAPI_SetsOutputConfig(t *testing.T) {

--- a/converters/converters_test.go
+++ b/converters/converters_test.go
@@ -1291,6 +1291,7 @@ func TestThinkingConfigToAnthropic_ModelAware(t *testing.T) {
 		wantAdaptive bool
 		wantBudget   int64
 		wantEffort   anthropic.OutputConfigEffort
+		wantDisplay  string
 	}{
 		// Model-aware level → adaptive + effort
 		{
@@ -1299,6 +1300,15 @@ func TestThinkingConfigToAnthropic_ModelAware(t *testing.T) {
 			model:        anthropic.ModelClaudeSonnet4_6,
 			wantAdaptive: true,
 			wantEffort:   anthropic.OutputConfigEffortHigh,
+			wantDisplay:  "omitted",
+		},
+		{
+			name:         "HIGH with IncludeThoughts on Sonnet 4.6 returns summaries",
+			cfg:          &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelHigh, IncludeThoughts: true},
+			model:        anthropic.ModelClaudeSonnet4_6,
+			wantAdaptive: true,
+			wantEffort:   anthropic.OutputConfigEffortHigh,
+			wantDisplay:  "summarized",
 		},
 		{
 			name:         "MEDIUM on Opus 4.6 → adaptive + medium effort",
@@ -1330,10 +1340,11 @@ func TestThinkingConfigToAnthropic_ModelAware(t *testing.T) {
 
 		// Non-adaptive models fall back to manual budget
 		{
-			name:       "HIGH on Haiku 4.5 → manual budget 10000 (no effort)",
-			cfg:        &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelHigh},
-			model:      anthropic.ModelClaudeHaiku4_5,
-			wantBudget: 10000,
+			name:        "HIGH on Haiku 4.5 → manual budget 10000 (no effort)",
+			cfg:         &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelHigh},
+			model:       anthropic.ModelClaudeHaiku4_5,
+			wantBudget:  10000,
+			wantDisplay: "omitted",
 		},
 		{
 			name:       "MEDIUM on Haiku 4.5 → manual budget 5000 (no effort)",
@@ -1348,26 +1359,35 @@ func TestThinkingConfigToAnthropic_ModelAware(t *testing.T) {
 			wantBudget: 1024,
 		},
 
-		// IncludeThoughts is ignored — it's an output-visibility flag, not a thinking toggle
+		// IncludeThoughts controls output visibility without enabling thinking.
 		{
-			name:         "IncludeThoughts ignored on Sonnet 4.6 → adaptive default, no effort",
+			name:         "IncludeThoughts on Sonnet 4.6 → adaptive default with summaries",
 			cfg:          &genai.ThinkingConfig{IncludeThoughts: true},
 			model:        anthropic.ModelClaudeSonnet4_6,
 			wantAdaptive: true,
+			wantDisplay:  "summarized",
 		},
 		{
-			name:    "IncludeThoughts ignored on Haiku 4.5 → off",
+			name:    "IncludeThoughts alone on Haiku 4.5 → off",
 			cfg:     &genai.ThinkingConfig{IncludeThoughts: true},
 			model:   anthropic.ModelClaudeHaiku4_5,
 			wantNil: true,
 		},
+		{
+			name:        "manual thinking with IncludeThoughts returns summaries",
+			cfg:         &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelHigh, IncludeThoughts: true},
+			model:       anthropic.ModelClaudeHaiku4_5,
+			wantBudget:  10000,
+			wantDisplay: "summarized",
+		},
 
 		// Explicit overrides remain authoritative
 		{
-			name:       "ThinkingBudget overrides level on any model",
-			cfg:        &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelHigh, ThinkingBudget: int32Ptr(2048)},
-			model:      anthropic.ModelClaudeSonnet4_6,
-			wantBudget: 2048,
+			name:        "ThinkingBudget overrides level on any model",
+			cfg:         &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelHigh, ThinkingBudget: int32Ptr(2048)},
+			model:       anthropic.ModelClaudeSonnet4_6,
+			wantBudget:  2048,
+			wantDisplay: "omitted",
 		},
 
 		// Empty model name (legacy single-arg behaviour) prefers manual budget
@@ -1399,6 +1419,7 @@ func TestThinkingConfigToAnthropic_ModelAware(t *testing.T) {
 			cfg:          nil,
 			model:        anthropic.ModelClaudeSonnet4_6,
 			wantAdaptive: true,
+			wantDisplay:  "omitted",
 		},
 		{
 			name:    "nil config on manual-only model → off",
@@ -1411,6 +1432,7 @@ func TestThinkingConfigToAnthropic_ModelAware(t *testing.T) {
 			cfg:          &genai.ThinkingConfig{},
 			model:        anthropic.ModelClaudeSonnet4_6,
 			wantAdaptive: true,
+			wantDisplay:  "omitted",
 		},
 		{
 			name:    "empty cfg on manual-only model → off",
@@ -1452,6 +1474,16 @@ func TestThinkingConfigToAnthropic_ModelAware(t *testing.T) {
 
 			if got.Effort != tt.wantEffort {
 				t.Errorf("Effort = %q, want %q", got.Effort, tt.wantEffort)
+			}
+
+			var display string
+			if got.Thinking.OfAdaptive != nil {
+				display = string(got.Thinking.OfAdaptive.Display)
+			} else if got.Thinking.OfEnabled != nil {
+				display = string(got.Thinking.OfEnabled.Display)
+			}
+			if tt.wantDisplay != "" && display != tt.wantDisplay {
+				t.Errorf("Display = %q, want %q", display, tt.wantDisplay)
 			}
 		})
 	}

--- a/converters/request.go
+++ b/converters/request.go
@@ -456,21 +456,22 @@ type ThinkingMapping struct {
 //  7. empty cfg (no fields set), adaptive-capable            → adaptive (default effort = high)
 //  8. empty cfg, manual-only                                 → off
 //
-// IncludeThoughts is ignored: in genai it governs whether thought summaries
-// are returned, not whether the model thinks, and Anthropic returns thinking
-// blocks whenever thinking is on regardless. Thinking is driven solely by
-// ThinkingBudget / ThinkingLevel and the per-tier default.
+// IncludeThoughts controls whether Anthropic returns summarized thinking text.
+// It maps to thinking.display without enabling or disabling thinking: true uses
+// "summarized", while false (including the zero value) uses "omitted". Thinking
+// itself remains driven solely by ThinkingBudget / ThinkingLevel and the
+// per-tier default.
 func ThinkingConfigToAnthropic(cfg *genai.ThinkingConfig, model anthropic.Model) ThinkingMapping {
 	adaptive := supportsAdaptiveThinking(model)
 
 	if cfg == nil {
 		if adaptive {
-			return ThinkingMapping{Thinking: adaptiveThinking()}
+			return ThinkingMapping{Thinking: adaptiveThinking(false)}
 		}
 		return ThinkingMapping{}
 	}
 	if cfg.ThinkingBudget != nil {
-		return ThinkingMapping{Thinking: anthropic.ThinkingConfigParamOfEnabled(int64(*cfg.ThinkingBudget))}
+		return ThinkingMapping{Thinking: enabledThinking(int64(*cfg.ThinkingBudget), cfg.IncludeThoughts)}
 	}
 
 	switch cfg.ThinkingLevel {
@@ -483,20 +484,18 @@ func ThinkingConfigToAnthropic(cfg *genai.ThinkingConfig, model anthropic.Model)
 	case genai.ThinkingLevelLow, genai.ThinkingLevelMedium, genai.ThinkingLevelHigh:
 		if adaptive {
 			return ThinkingMapping{
-				Thinking: adaptiveThinking(),
+				Thinking: adaptiveThinking(cfg.IncludeThoughts),
 				Effort:   levelToEffort(cfg.ThinkingLevel),
 			}
 		}
-		return ThinkingMapping{Thinking: anthropic.ThinkingConfigParamOfEnabled(levelToBudget(cfg.ThinkingLevel))}
+		return ThinkingMapping{Thinking: enabledThinking(levelToBudget(cfg.ThinkingLevel), cfg.IncludeThoughts)}
 	}
 
-	// IncludeThoughts is intentionally ignored — see the doc comment above.
-	//
 	// Empty cfg (no fields set, or only IncludeThoughts) — same as nil: pick
 	// the per-tier default. Callers who want thinking off on an adaptive-capable
 	// model must say so explicitly via ThinkingLevel: Minimal.
 	if adaptive {
-		return ThinkingMapping{Thinking: adaptiveThinking()}
+		return ThinkingMapping{Thinking: adaptiveThinking(cfg.IncludeThoughts)}
 	}
 	return ThinkingMapping{}
 }
@@ -505,7 +504,8 @@ func ThinkingConfigToAnthropic(cfg *genai.ThinkingConfig, model anthropic.Model)
 // callers that don't have a model handy and don't care about the effort
 // hint. Equivalent to ThinkingConfigToAnthropic(cfg, "").Thinking — empty
 // model means "treat as non-adaptive", so Low/High/explicit ThinkingBudget
-// keep their v0.1.9 manual-budget mapping (IncludeThoughts is ignored).
+// keep their v0.1.9 manual-budget mapping. IncludeThoughts controls display
+// whenever thinking is enabled.
 //
 // One small behaviour shift vs v0.1.9 worth knowing about: ThinkingLevel:
 // Medium previously fell through v0.1.9's switch (which only enumerated
@@ -522,9 +522,28 @@ func ThinkingConfigToAnthropicThinking(cfg *genai.ThinkingConfig) anthropic.Thin
 }
 
 // adaptiveThinking returns the parameter union for Anthropic adaptive mode.
-func adaptiveThinking() anthropic.ThinkingConfigParamUnion {
+func adaptiveThinking(includeThoughts bool) anthropic.ThinkingConfigParamUnion {
+	display := anthropic.ThinkingConfigAdaptiveDisplayOmitted
+	if includeThoughts {
+		display = anthropic.ThinkingConfigAdaptiveDisplaySummarized
+	}
 	return anthropic.ThinkingConfigParamUnion{
-		OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{},
+		OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{Display: display},
+	}
+}
+
+// enabledThinking returns a manual thinking configuration with display mapped
+// independently from the reasoning budget.
+func enabledThinking(budget int64, includeThoughts bool) anthropic.ThinkingConfigParamUnion {
+	display := anthropic.ThinkingConfigEnabledDisplayOmitted
+	if includeThoughts {
+		display = anthropic.ThinkingConfigEnabledDisplaySummarized
+	}
+	return anthropic.ThinkingConfigParamUnion{
+		OfEnabled: &anthropic.ThinkingConfigEnabledParam{
+			BudgetTokens: budget,
+			Display:      display,
+		},
 	}
 }
 

--- a/converters/tools.go
+++ b/converters/tools.go
@@ -272,6 +272,61 @@ func SchemaToMap(schema *genai.Schema) map[string]any {
 	return result
 }
 
+// SchemaToStructuredOutputMap converts a genai schema and applies Anthropic's
+// structured-output compatibility transformation. The SDK currently exposes
+// this transformation through a legacy Beta-named helper; only its transformed
+// schema map is used here with the GA output_config API.
+func SchemaToStructuredOutputMap(schema *genai.Schema) (map[string]any, error) {
+	schemaMap := SchemaToMap(schema)
+	preserveUnsupportedNumericConstraints(schemaMap)
+	transformed := anthropic.BetaJSONSchemaOutputFormat(schemaMap).Schema
+	result, ok := transformed.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("Anthropic schema transformer returned %T, want map[string]any", transformed)
+	}
+	return result, nil
+}
+
+// preserveUnsupportedNumericConstraints moves numeric constraints Anthropic's
+// structured-output grammar does not support into descriptions before invoking
+// the SDK transformer. Doing this while they are scalar map values avoids the
+// SDK's JSON-schema round trip rendering pointer-backed values as addresses.
+func preserveUnsupportedNumericConstraints(node any) {
+	switch n := node.(type) {
+	case map[string]any:
+		var extras []string
+		for _, key := range []string{"maxItems", "maxLength", "maximum", "minLength", "minimum"} {
+			if value, exists := n[key]; exists {
+				extras = append(extras, fmt.Sprintf("%s: %v", key, value))
+				delete(n, key)
+			}
+		}
+		if value, exists := n["minItems"]; exists && value != int64(0) && value != int64(1) {
+			extras = append(extras, fmt.Sprintf("minItems: %v", value))
+			delete(n, "minItems")
+		}
+		if len(extras) > 0 {
+			extraDescription := "{" + strings.Join(extras, ", ") + "}"
+			if description, _ := n["description"].(string); description != "" {
+				n["description"] = description + "\n\n" + extraDescription
+			} else {
+				n["description"] = extraDescription
+			}
+		}
+		for _, value := range n {
+			preserveUnsupportedNumericConstraints(value)
+		}
+	case []map[string]any:
+		for _, value := range n {
+			preserveUnsupportedNumericConstraints(value)
+		}
+	case []any:
+		for _, value := range n {
+			preserveUnsupportedNumericConstraints(value)
+		}
+	}
+}
+
 // toolChoiceKind represents the resolved tool choice type.
 type toolChoiceKind int
 


### PR DESCRIPTION
## Problem

- Vertex structured outputs can send JSON Schema constraints that Anthropic does not support.
- `IncludeThoughts` is ignored, so thought summaries can be returned when callers did not request them.

## Solution

- Transform response schemas through Anthropic's compatibility rules while preserving unsupported constraints in field descriptions.
- Map `IncludeThoughts` to Anthropic's `summarized` or `omitted` display mode without changing whether thinking is enabled.