### PR TITLE
Drop hidden thoughts from Anthropic user messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v2.0.4] - Drop hidden thoughts from user messages
+
+- Prevent Anthropic 400 errors when ADK converts foreign-agent output to user context by dropping hidden thought parts only from user-role messages. Assistant-role signed and redacted thinking continuity remains unchanged.
+- This is a temporary compatibility guard for [google/adk-go#1104](https://github.com/google/adk-go/pull/1104) and can be removed once the minimum supported adk-go version includes that fix.
+
 ## [v2.0.3] - Model-aware max_tokens and interrupted-output detection
 
 - Default `max_tokens` per model instead of a flat 16384. Each model now defaults to its output ceiling — 128000 for Sonnet 4.6 and Opus 4.x, 64000 for Haiku 4.5 and unrecognised models — resolved from the model id (tolerant of Vertex-style dated `@` suffixes). `max_tokens` is a ceiling, not a target, so this gives callers the model's full output budget (converging with Gemini, which treats an unset limit as the model maximum) and stops adaptive thinking from sharing a budget so small it truncates tool calls mid-generation. A per-request `GenerateContentConfig.MaxOutputTokens` and deployment-level `Config.DefaultMaxTokens` still override it.

--- a/converters/converters_test.go
+++ b/converters/converters_test.go
@@ -213,6 +213,79 @@ func TestContentsToMessages_PreservesRedactedThinkingBoundary(t *testing.T) {
 	}
 }
 
+func TestContentsToMessages_DropsThoughtsFromUserMessages(t *testing.T) {
+	var redactedBlock anthropic.ContentBlockUnion
+	if err := redactedBlock.UnmarshalJSON([]byte(`{
+		"type": "redacted_thinking",
+		"data": "opaque-redacted-data"
+	}`)); err != nil {
+		t.Fatalf("failed to unmarshal redacted thinking block: %v", err)
+	}
+	redactedPart, err := converters.ContentBlockToGenaiPart(redactedBlock)
+	if err != nil {
+		t.Fatalf("ContentBlockToGenaiPart() error = %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		thought *genai.Part
+	}{
+		{
+			name: "empty signed thought",
+			thought: &genai.Part{
+				Thought:          true,
+				ThoughtSignature: []byte("signature"),
+			},
+		},
+		{
+			name: "non-empty signed thought",
+			thought: &genai.Part{
+				Text:             "Hidden reasoning",
+				Thought:          true,
+				ThoughtSignature: []byte("signature"),
+			},
+		},
+		{
+			name:    "redacted thought",
+			thought: redactedPart,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages, err := converters.ContentsToMessages([]*genai.Content{
+				{
+					Role: "user",
+					Parts: []*genai.Part{
+						{Text: "For context: [researcher] said: relevant result"},
+						tt.thought,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("ContentsToMessages() error = %v", err)
+			}
+
+			if len(messages) != 1 {
+				t.Fatalf("expected 1 message, got %d", len(messages))
+			}
+			if messages[0].Role != anthropic.MessageParamRoleUser {
+				t.Errorf("role = %q, want %q", messages[0].Role, anthropic.MessageParamRoleUser)
+			}
+			if len(messages[0].Content) != 1 {
+				t.Fatalf("expected only the context text block, got %d blocks", len(messages[0].Content))
+			}
+			textBlock := messages[0].Content[0].OfText
+			if textBlock == nil {
+				t.Fatal("user message does not contain the context text block")
+			}
+			if textBlock.Text != "For context: [researcher] said: relevant result" {
+				t.Errorf("text = %q, want the original context", textBlock.Text)
+			}
+		})
+	}
+}
+
 func TestThinkingBlock_RoundTripsThroughPersistedPart(t *testing.T) {
 	var responseBlock anthropic.ContentBlockUnion
 	if err := responseBlock.UnmarshalJSON([]byte(`{

--- a/converters/request.go
+++ b/converters/request.go
@@ -106,6 +106,13 @@ func contentToMessage(content *genai.Content) (*anthropic.MessageParam, error) {
 		if part == nil {
 			continue
 		}
+		// TODO: Remove this compatibility guard once the minimum adk-go version
+		// includes https://github.com/google/adk-go/pull/1104. Older versions can
+		// retain a foreign agent's hidden thoughts while changing its role to user,
+		// but Anthropic only accepts thinking blocks in assistant messages.
+		if role == anthropic.MessageParamRoleUser && part.Thought {
+			continue
+		}
 		block, err := PartToContentBlock(part)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert part: %w", err)


### PR DESCRIPTION
Fixes [AI-1853](https://linear.app/alcova/issue/AI-1853/prevent-hidden-sub-agent-thinking-from-becoming-user-content).

Google ADK can carry Anthropic omitted thinking blocks—an empty `thinking` field with a signature—into user-role foreign-agent context, causing Anthropic to reject the request. This adds a temporary adapter guard that drops thought-marked parts from user messages while preserving assistant thinking continuity.

This guard addresses the omitted-thinking form whose `Part.Thought` marker survives ADK conversion. Non-empty foreign thoughts are rewritten to ordinary text before reaching this adapter and remain covered by [google/adk-go#1104](https://github.com/google/adk-go/pull/1104).

The guard can be removed once the minimum supported adk-go release includes that upstream fix.