### PR TITLE
AI-1854: Restore safe default max_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v2.0.5] - Restore safe default max tokens
+
+- Restore the transport-independent `max_tokens` default to 16384. The v2.0.3 model-ceiling defaults caused Anthropic's Go SDK to reject non-streaming requests before sending them because 64000 and 128000 tokens exceed its ten-minute non-streaming estimate. Streaming callers that need larger outputs should set `GenerateContentConfig.MaxOutputTokens` or `Config.DefaultMaxTokens` explicitly.
+
 ## [v2.0.4] - Drop hidden thoughts from user messages
 
 - Prevent Anthropic 400 errors when ADK converts foreign-agent output to user context by dropping hidden thought parts only from user-role messages. Assistant-role signed and redacted thinking continuity remains unchanged.

--- a/anthropic.go
+++ b/anthropic.go
@@ -29,6 +29,8 @@ import (
 	"google.golang.org/adk/v2/model"
 )
 
+const defaultMaxTokens = 16384
+
 type anthropicModel struct {
 	client           anthropic.Client
 	name             anthropic.Model
@@ -83,12 +85,12 @@ func NewModel(ctx context.Context, modelName anthropic.Model, cfg *Config) (mode
 	}
 
 	// max_tokens precedence: a per-request GenerateContentConfig.MaxOutputTokens
-	// override wins in convertRequest; a deployment-level Config.DefaultMaxTokens wins here;
-	// otherwise fall back to the model's ceiling. Resolving once at construction
-	// is sufficient because the model name is fixed per instance.
+	// override wins in convertRequest; a deployment-level Config.DefaultMaxTokens
+	// wins here; otherwise use a conservative default that remains valid for
+	// both streaming and non-streaming requests.
 	maxTokens := cfg.DefaultMaxTokens
 	if maxTokens == 0 {
-		maxTokens = converters.DefaultMaxTokensForModel(modelName)
+		maxTokens = defaultMaxTokens
 	}
 
 	return &anthropicModel{

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -18,15 +18,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/anthropics/anthropic-sdk-go"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/genai"
-
-	"github.com/Alcova-AI/adk-anthropic-go/v2/converters"
 )
 
 // testMaxTokens is an arbitrary non-zero max_tokens for constructing model
-// fixtures in tests that don't exercise token-limit behaviour. Tests that do
-// assert on the resolved ceiling use converters.MaxTokens* directly.
+// fixtures in tests that don't exercise token-limit behaviour.
 const testMaxTokens = 64000
 
 func TestNewModel_ConfigBehavior(t *testing.T) {
@@ -47,14 +45,12 @@ func TestNewModel_ConfigBehavior(t *testing.T) {
 			wantVariant:   VariantAnthropicAPI,
 		},
 		{
-			// No explicit DefaultMaxTokens: falls back to the per-model ceiling.
-			// claude-sonnet-4-20250514 isn't in the table, so it gets the floor.
-			name: "default_max_tokens_falls_back_to_model_ceiling",
+			name: "default_max_tokens_is_safe_for_non_streaming",
 			cfg: &Config{
 				APIKey:  "test-api-key",
 				Variant: VariantAnthropicAPI,
 			},
-			wantMaxTokens: converters.MaxTokensFloor,
+			wantMaxTokens: defaultMaxTokens,
 			wantVariant:   VariantAnthropicAPI,
 		},
 	}
@@ -78,6 +74,21 @@ func TestNewModel_ConfigBehavior(t *testing.T) {
 				t.Errorf("variant = %q, want %q", am.variant, tt.wantVariant)
 			}
 		})
+	}
+}
+
+func TestNewModel_DefaultMaxTokensSupportsNonStreaming(t *testing.T) {
+	model, err := NewModel(t.Context(), anthropic.ModelClaudeHaiku4_5, &Config{
+		APIKey:  "test-api-key",
+		Variant: VariantAnthropicAPI,
+	})
+	if err != nil {
+		t.Fatalf("NewModel() error = %v", err)
+	}
+
+	maxTokens := model.(*anthropicModel).defaultMaxTokens
+	if _, err := anthropic.CalculateNonStreamingTimeout(maxTokens, anthropic.ModelClaudeHaiku4_5, nil); err != nil {
+		t.Fatalf("default max_tokens %d is incompatible with non-streaming requests: %v", maxTokens, err)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -68,10 +68,10 @@ type Config struct {
 
 	// DefaultMaxTokens is the default maximum number of tokens to generate.
 	// Anthropic requires max_tokens to be explicitly set for all requests.
-	// If not provided, it defaults to the model's output ceiling (see
-	// converters.DefaultMaxTokensForModel): 128000 for Sonnet 4.6 and Opus
-	// 4.x, 64000 for Haiku 4.5 and unrecognised models. A per-request
-	// GenerateContentConfig.MaxOutputTokens still overrides this.
+	// If not provided, it defaults to 16384 so both streaming and non-streaming
+	// requests remain valid. Callers that intentionally stream large outputs
+	// should set a larger deployment-level value or use the per-request
+	// GenerateContentConfig.MaxOutputTokens override.
 	DefaultMaxTokens int
 
 	BaseURL string

--- a/converters/converters_test.go
+++ b/converters/converters_test.go
@@ -1717,36 +1717,6 @@ func TestUsageToMetadata_CacheTokens(t *testing.T) {
 	})
 }
 
-func TestDefaultMaxTokensForModel(t *testing.T) {
-	cases := []struct {
-		name  string
-		model anthropic.Model
-		want  int
-	}{
-		{"sonnet_4_6", "claude-sonnet-4-6", 128000},
-		{"sonnet_4_6_dated", "claude-sonnet-4-6-20250101", 128000},
-		{"sonnet_4_6_vertex_suffix", "claude-sonnet-4-6@20250101", 128000},
-		{"opus_4_6", "claude-opus-4-6", 128000},
-		{"opus_4_7", "claude-opus-4-7", 128000},
-		{"opus_4_8", "claude-opus-4-8", 128000},
-		{"opus_4_8_vertex_suffix", "claude-opus-4-8@20260101", 128000},
-		{"haiku_4_5", "claude-haiku-4-5", 64000},
-		{"haiku_4_5_dated", "claude-haiku-4-5-20251001", 64000},
-		{"uppercase_normalised", "Claude-Sonnet-4-6@20250101", 128000},
-		{"unknown_sonnet_4", "claude-sonnet-4-20250514", 64000},
-		{"unknown_future_model", "claude-something-9", 64000},
-		{"empty", "", 64000},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := converters.DefaultMaxTokensForModel(tc.model); got != tc.want {
-				t.Errorf("DefaultMaxTokensForModel(%q) = %d, want %d", tc.model, got, tc.want)
-			}
-		})
-	}
-}
-
 // truncatedToolMessage builds an accumulated message whose trailing tool_use
 // block was cut off mid-input: a signed thinking block, a completed text
 // block, a completed tool call with valid input, then a tool call whose

--- a/converters/request.go
+++ b/converters/request.go
@@ -554,55 +554,6 @@ func enabledThinking(budget int64, includeThoughts bool) anthropic.ThinkingConfi
 	}
 }
 
-// Per-model default max_tokens ceilings. max_tokens is a *ceiling*, not a
-// target: Anthropic requires it on every request, whereas Gemini treats an
-// unset limit as the model maximum. Defaulting each model to its real output
-// ceiling converges the two providers' semantics — callers get the model's
-// full output budget unless they deliberately cap it. Adaptive thinking draws
-// from this same budget, so a ceiling set too low truncates tool calls
-// mid-generation (the failure this table exists to prevent). The table is
-// static because the Models API that would report these limits is unavailable
-// on Vertex AI.
-const (
-	// MaxTokensSonnetOpus is the default max_tokens ceiling for Sonnet 4.6 and
-	// Opus 4.x.
-	MaxTokensSonnetOpus = 128000
-	// MaxTokensHaiku is the default max_tokens ceiling for Haiku 4.5.
-	MaxTokensHaiku = 64000
-	// MaxTokensFloor is the conservative default for models we don't recognise.
-	MaxTokensFloor = 64000
-)
-
-// DefaultMaxTokensForModel returns the default max_tokens ceiling for a model
-// when the caller hasn't set one explicitly. It matches on the normalised
-// model id (lower-cased, Vertex-style dated `@` suffix stripped) so both the
-// direct-API aliases (claude-sonnet-4-6) and Vertex dated ids
-// (claude-sonnet-4-6@20250101) resolve to the same ceiling. Unrecognised
-// models fall back to the conservative floor.
-func DefaultMaxTokensForModel(model anthropic.Model) int {
-	id := normalizeModelID(model)
-	switch {
-	case strings.HasPrefix(id, "claude-sonnet-4-6"):
-		return MaxTokensSonnetOpus
-	case strings.HasPrefix(id, "claude-opus-4-"):
-		return MaxTokensSonnetOpus
-	case strings.HasPrefix(id, "claude-haiku-4-5"):
-		return MaxTokensHaiku
-	default:
-		return MaxTokensFloor
-	}
-}
-
-// normalizeModelID lower-cases a model id and strips any Vertex-style dated
-// `@` suffix, so prefix matching is tolerant of both id styles.
-func normalizeModelID(model anthropic.Model) string {
-	id := strings.ToLower(string(model))
-	if i := strings.IndexByte(id, '@'); i >= 0 {
-		id = id[:i]
-	}
-	return id
-}
-
 // supportsAdaptiveThinking reports whether `model` accepts adaptive thinking
 // (thinking: {type: "adaptive"}). Matches against the SDK's canonical
 // unversioned aliases — when Anthropic ships a new adaptive-capable model


### PR DESCRIPTION
## Problem

- v2.0.3 defaulted max_tokens to model ceilings.
- The Anthropic SDK rejects non-streaming calls whose estimated duration exceeds 10 minutes before sending them.

## Solution

- restore the safe 16,384 adapter default
- remove the unused per-model ceiling resolver and constants
- require callers that need larger streaming outputs to set an explicit override
- add regression coverage using the SDK timeout calculation
- add the separate v2.0.5 changelog entry after PR #29's v2.0.4 entry

## Checks

- go test ./... -count=1
- go vet ./...