### PR TITLE
Preserve function response media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v2.0.6] - Preserve function response media
+
+- Convert `FunctionResponse.Parts` into image and PDF content nested inside the matching Anthropic `tool_result`. Tool-returned media now stays correlated with its tool call instead of requiring separate user-message parts that can violate Anthropic's tool-result ordering rules.
+
 ## [v2.0.5] - Restore safe default max tokens
 
 - Restore the transport-independent `max_tokens` default to 16384. The v2.0.3 model-ceiling defaults caused Anthropic's Go SDK to reject non-streaming requests before sending them because 64000 and 128000 tokens exceed its ten-minute non-streaming estimate. Streaming callers that need larger outputs should set `GenerateContentConfig.MaxOutputTokens` or `Config.DefaultMaxTokens` explicitly.

--- a/converters/converters_test.go
+++ b/converters/converters_test.go
@@ -678,6 +678,89 @@ func TestFunctionResponseToBlock(t *testing.T) {
 	}
 }
 
+func TestFunctionResponseToBlock_PreservesInlineParts(t *testing.T) {
+	content := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{{
+			FunctionResponse: &genai.FunctionResponse{
+				ID:       "call_123",
+				Name:     "read_file",
+				Response: map[string]any{"path": "/report.pdf"},
+				Parts: []*genai.FunctionResponsePart{
+					genai.NewFunctionResponsePartFromBytes([]byte("image"), "image/png"),
+					genai.NewFunctionResponsePartFromBytes([]byte("pdf"), "application/pdf"),
+					genai.NewFunctionResponsePartFromURI("https://example.com/image.png", "image/png"),
+				},
+			},
+		}},
+	}
+
+	messages, err := converters.ContentsToMessages([]*genai.Content{content})
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+	if len(messages) != 1 || len(messages[0].Content) != 1 {
+		t.Fatalf("expected one message with one tool result, got %#v", messages)
+	}
+
+	result := messages[0].Content[0].OfToolResult
+	if result == nil {
+		t.Fatal("expected tool result block")
+	}
+	if len(result.Content) != 4 {
+		t.Fatalf("expected JSON, inline image, PDF, and URL image inside tool result, got %d blocks", len(result.Content))
+	}
+	if result.Content[0].OfText == nil || result.Content[0].OfText.Text != `{"path":"/report.pdf"}` {
+		t.Errorf("unexpected JSON result block: %#v", result.Content[0])
+	}
+	if result.Content[1].OfImage == nil || result.Content[1].OfImage.Source.OfBase64 == nil {
+		t.Errorf("expected inline image inside tool result, got %#v", result.Content[1])
+	}
+	if result.Content[2].OfDocument == nil || result.Content[2].OfDocument.Source.OfBase64 == nil {
+		t.Errorf("expected inline PDF inside tool result, got %#v", result.Content[2])
+	}
+	if result.Content[3].OfImage == nil || result.Content[3].OfImage.Source.OfURL == nil {
+		t.Errorf("expected URL image inside tool result, got %#v", result.Content[3])
+	}
+}
+
+func TestFunctionResponseToBlock_ParallelResultsStayContiguous(t *testing.T) {
+	content := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{
+				ID:       "call_1",
+				Name:     "read_file",
+				Response: map[string]any{"path": "/one.png"},
+				Parts:    []*genai.FunctionResponsePart{genai.NewFunctionResponsePartFromBytes([]byte("one"), "image/png")},
+			}},
+			{FunctionResponse: &genai.FunctionResponse{
+				ID:       "call_2",
+				Name:     "read_file",
+				Response: map[string]any{"path": "/two.png"},
+				Parts:    []*genai.FunctionResponsePart{genai.NewFunctionResponsePartFromBytes([]byte("two"), "image/png")},
+			}},
+		},
+	}
+
+	messages, err := converters.ContentsToMessages([]*genai.Content{content})
+	if err != nil {
+		t.Fatalf("ContentsToMessages() error = %v", err)
+	}
+	if len(messages) != 1 || len(messages[0].Content) != 2 {
+		t.Fatalf("expected one message with two contiguous tool results, got %#v", messages)
+	}
+	for i, block := range messages[0].Content {
+		if block.OfToolResult == nil {
+			t.Errorf("content block %d is not a tool result: %#v", i, block)
+			continue
+		}
+		if len(block.OfToolResult.Content) != 2 || block.OfToolResult.Content[1].OfImage == nil {
+			t.Errorf("tool result %d does not contain its image: %#v", i, block.OfToolResult)
+		}
+	}
+}
+
 func TestFunctionResponseToBlock_RequiresID(t *testing.T) {
 	content := &genai.Content{
 		Role: "user",

--- a/converters/request.go
+++ b/converters/request.go
@@ -321,18 +321,74 @@ func functionResponseToBlock(resp *genai.FunctionResponse) (*anthropic.ContentBl
 		return nil, fmt.Errorf("FunctionResponse.ID is required for tool call correlation (function: %s)", resp.Name)
 	}
 
-	// Convert the response to JSON string
-	var content string
+	var content []anthropic.ToolResultBlockParamContentUnion
 	if resp.Response != nil {
 		jsonBytes, err := json.Marshal(resp.Response)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal function response: %w", err)
 		}
-		content = string(jsonBytes)
+		content = append(content, anthropic.ToolResultBlockParamContentUnion{
+			OfText: &anthropic.TextBlockParam{Text: string(jsonBytes)},
+		})
 	}
 
-	block := anthropic.NewToolResultBlock(resp.ID, content, false)
+	for _, part := range resp.Parts {
+		converted, err := functionResponsePartToBlock(part)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert function response part: %w", err)
+		}
+		if converted != nil {
+			content = append(content, *converted)
+		}
+	}
+
+	block := anthropic.ContentBlockParamUnion{
+		OfToolResult: &anthropic.ToolResultBlockParam{
+			ToolUseID: resp.ID,
+			Content:   content,
+			IsError:   anthropic.Bool(false),
+		},
+	}
 	return &block, nil
+}
+
+func functionResponsePartToBlock(part *genai.FunctionResponsePart) (*anthropic.ToolResultBlockParamContentUnion, error) {
+	if part == nil {
+		return nil, nil
+	}
+
+	var block *anthropic.ContentBlockParamUnion
+	var err error
+	switch {
+	case part.InlineData != nil:
+		block, err = inlineDataToBlock(&genai.Blob{
+			Data:     part.InlineData.Data,
+			MIMEType: part.InlineData.MIMEType,
+		})
+	case part.FileData != nil:
+		block, err = fileDataToBlock(&genai.FileData{
+			FileURI:     part.FileData.FileURI,
+			MIMEType:    part.FileData.MIMEType,
+			DisplayName: part.FileData.DisplayName,
+		})
+	default:
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if block == nil {
+		return nil, nil
+	}
+
+	switch {
+	case block.OfImage != nil:
+		return &anthropic.ToolResultBlockParamContentUnion{OfImage: block.OfImage}, nil
+	case block.OfDocument != nil:
+		return &anthropic.ToolResultBlockParamContentUnion{OfDocument: block.OfDocument}, nil
+	default:
+		return nil, fmt.Errorf("unsupported function response content block")
+	}
 }
 
 // functionCallToBlock converts a FunctionCall to an Anthropic tool use block.


### PR DESCRIPTION
## Problem

FunctionResponse.Parts were ignored by the Anthropic adapter. Applications had to emit tool-returned media as separate user-message parts, which could break Anthropic tool-result ordering.

## Solution

- Convert inline and URI-backed images and PDFs into content nested inside the matching tool_result.
- Keep parallel tool results contiguous while preserving each result media.
- Add the v2.0.6 changelog entry for the automated release.