### PR TITLE
Separate canonical and request model names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
-## [v2.0.8] - Add request model overrides
+## [v2.0.9] - Add request model overrides
 
 - Add `Config.RequestModel` for Anthropic-compatible APIs that require a different model identifier on the wire. Capability checks and `Name()` continue to use the canonical model passed to `NewModel`.
 - Reject unknown backend variants during model construction.
+
+## [v2.0.8] - Preserve cache creation usage
+
+- Preserve aggregate, five-minute, and one-hour Anthropic cache creation token counts in `LLMResponse.CustomMetadata` for streaming and non-streaming responses.
 
 ## [v2.0.7] - Retry mid-stream overload errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [v2.0.8] - Add Vercel AI Gateway transport
+## [v2.0.8] - Add request model overrides
 
-- Add an explicit Vercel AI Gateway variant using its Anthropic-compatible endpoint. Canonical Claude Sonnet 4.6 and Haiku 4.5 aliases are remapped to Vercel's creator/model IDs on the wire while capability checks and `Name()` keep using the canonical Anthropic names. Other gateway-qualified model IDs pass through unchanged.
-- Reject missing Vercel API keys and unknown variants during model construction.
+- Add `Config.RequestModel` for Anthropic-compatible APIs that require a different model identifier on the wire. Capability checks and `Name()` continue to use the canonical model passed to `NewModel`.
+- Reject unknown backend variants during model construction.
 
 ## [v2.0.7] - Retry mid-stream overload errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v2.0.8] - Add Vercel AI Gateway transport
+
+- Add an explicit Vercel AI Gateway variant using its Anthropic-compatible endpoint. Canonical Claude Sonnet 4.6 and Haiku 4.5 aliases are remapped to Vercel's creator/model IDs on the wire while capability checks and `Name()` keep using the canonical Anthropic names. Other gateway-qualified model IDs pass through unchanged.
+- Reject missing Vercel API keys and unknown variants during model construction.
+
 ## [v2.0.7] - Retry mid-stream overload errors
 
 - Retry streaming requests when Anthropic reports `overloaded_error` mid-stream. Vertex AI can accept a streaming request (HTTP 200 at the header level) and then deliver `{"type":"error","error":{"type":"overloaded_error"}}` as an SSE `error` event; the SDK's HTTP-level retries never see it because the request already succeeded. `generateStream` now makes up to 3 attempts with ~1s/~2s jittered backoff, aborting promptly on context cancellation — but only while nothing has been yielded to the consumer. Once a text or thinking delta has streamed, a retry would duplicate content, so the error surfaces immediately as before. The retry is scoped to overloads delivered inside an HTTP 200 stream: a direct-API HTTP 529 has already exhausted the SDK's own retries and is not retried again by the adapter. On exhaustion the error is wrapped exactly as before (`stream error: %w`), preserving caller-side `errors.As` detection and error grouping. This is a deliberate, narrow exception to the adapter's "no continuation decisions" rule (v2.0.3): a pre-content overload retry is invisible to callers and carries no continuation semantics. The non-streaming path is unchanged — overload there arrives as HTTP 529 and is already covered by the SDK's default retries.

--- a/README.md
+++ b/README.md
@@ -135,14 +135,14 @@ type Config struct {
 	// Backend variant: VariantAnthropicAPI or VariantVertexAI
 	Variant string
 
-	// Optional endpoint for proxies and Anthropic-compatible APIs
+	// Optional endpoint for proxies and Anthropic-compatible APIs.
+	// Ignored for Vertex AI.
 	BaseURL string
 
 	// Optional model identifier sent to the API
 	RequestModel anthropic.Model
 
-	// Default max tokens (default: the model's output ceiling —
-	// 128000 for Sonnet 4.6 / Opus 4.x, 64000 for Haiku 4.5 and unknown models)
+	// Default max tokens (default: 16384)
 	DefaultMaxTokens int
 }
 ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,21 @@ model, err := adkanthropic.NewModel(ctx, "claude-sonnet-4@20250514", &adkanthrop
 
 Or set `ANTHROPIC_USE_VERTEX=1` to use Vertex AI without specifying the variant in code.
 
+### Anthropic-Compatible APIs
+
+Use `BaseURL` to select a compatible endpoint. Set `RequestModel` when that
+endpoint expects a different model identifier from the canonical Anthropic name:
+
+```go
+model, err := adkanthropic.NewModel(ctx, anthropic.ModelClaudeSonnet4_6, &adkanthropic.Config{
+	APIKey:       os.Getenv("GATEWAY_API_KEY"),
+	BaseURL:      "https://gateway.example.com",
+	RequestModel: "provider/claude-sonnet-4.6",
+})
+```
+
+`model.Name()` and capability checks continue to use the canonical model name.
+
 ### Environment Variables
 
 | Variable | Description |
@@ -119,6 +134,12 @@ type Config struct {
 
 	// Backend variant: VariantAnthropicAPI or VariantVertexAI
 	Variant string
+
+	// Optional endpoint for proxies and Anthropic-compatible APIs
+	BaseURL string
+
+	// Optional model identifier sent to the API
+	RequestModel anthropic.Model
 
 	// Default max tokens (default: the model's output ceiling —
 	// 128000 for Sonnet 4.6 / Opus 4.x, 64000 for Haiku 4.5 and unknown models)

--- a/anthropic.go
+++ b/anthropic.go
@@ -33,7 +33,12 @@ import (
 	"google.golang.org/adk/v2/model"
 )
 
-const defaultMaxTokens = 16384
+const (
+	defaultMaxTokens          = 16384
+	defaultVercelGatewayURL   = "https://ai-gateway.vercel.sh"
+	vercelClaudeSonnet46Model = "anthropic/claude-sonnet-4.6"
+	vercelClaudeHaiku45Model  = "anthropic/claude-haiku-4.5"
+)
 
 // Mid-stream overload retry policy. Vertex AI can accept a streaming request
 // (HTTP 200 at the header level) and then deliver overloaded_error as an SSE
@@ -48,6 +53,7 @@ const (
 type anthropicModel struct {
 	client           anthropic.Client
 	name             anthropic.Model
+	requestModel     anthropic.Model
 	variant          string
 	defaultMaxTokens int
 	promptCaching    *PromptCachingConfig
@@ -67,6 +73,10 @@ type anthropicModel struct {
 //
 // For Vertex AI, set VertexProjectID and VertexLocation in the config or use
 // GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION environment variables.
+//
+// For Vercel AI Gateway, set VariantVercelAIGateway and provide its API key.
+// Canonical Claude aliases are translated to Vercel model IDs on the wire,
+// while Name continues to return the canonical model name.
 func NewModel(ctx context.Context, modelName anthropic.Model, cfg *Config) (model.LLM, error) {
 	if cfg == nil {
 		cfg = &Config{}
@@ -98,8 +108,15 @@ func NewModel(ctx context.Context, modelName anthropic.Model, cfg *Config) (mode
 		}
 
 		client = newVertexClient(ctx, cfg)
-	default:
+	case VariantVercelAIGateway:
+		if cfg.APIKey == "" {
+			return nil, errors.New("APIKey is required for Vercel AI Gateway")
+		}
+		client = newVercelGatewayClient(cfg)
+	case VariantAnthropicAPI:
 		client = newAPIClient(cfg)
+	default:
+		return nil, fmt.Errorf("unsupported Anthropic variant %q", variant)
 	}
 
 	// max_tokens precedence: a per-request GenerateContentConfig.MaxOutputTokens
@@ -114,11 +131,41 @@ func NewModel(ctx context.Context, modelName anthropic.Model, cfg *Config) (mode
 	return &anthropicModel{
 		client:           client,
 		name:             modelName,
+		requestModel:     requestModelForVariant(modelName, variant),
 		variant:          variant,
 		defaultMaxTokens: maxTokens,
 		promptCaching:    cfg.PromptCaching,
 		retrySleep:       sleepWithContext,
 	}, nil
+}
+
+// newVercelGatewayClient creates a client for Vercel AI Gateway's
+// Anthropic-compatible API.
+func newVercelGatewayClient(cfg *Config) anthropic.Client {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultVercelGatewayURL
+	}
+
+	return anthropic.NewClient(
+		option.WithAPIKey(cfg.APIKey),
+		option.WithBaseURL(baseURL),
+	)
+}
+
+func requestModelForVariant(modelName anthropic.Model, variant string) anthropic.Model {
+	if variant != VariantVercelAIGateway {
+		return modelName
+	}
+
+	switch modelName {
+	case anthropic.ModelClaudeSonnet4_6:
+		return vercelClaudeSonnet46Model
+	case anthropic.ModelClaudeHaiku4_5:
+		return vercelClaudeHaiku45Model
+	default:
+		return modelName
+	}
 }
 
 // newAPIClient creates a client for the direct Anthropic API.
@@ -161,6 +208,13 @@ func newVertexClient(ctx context.Context, cfg *Config) anthropic.Client {
 // Name returns the model name.
 func (m *anthropicModel) Name() string {
 	return string(m.name)
+}
+
+func (m *anthropicModel) wireModel() anthropic.Model {
+	if m.requestModel != "" {
+		return m.requestModel
+	}
+	return m.name
 }
 
 // GenerateContent calls the Anthropic model.
@@ -365,7 +419,7 @@ func (m *anthropicModel) convertRequest(req *model.LLMRequest) (anthropic.Messag
 	}
 
 	params := anthropic.MessageNewParams{
-		Model:     anthropic.Model(m.name),
+		Model:     m.wireModel(),
 		Messages:  messages,
 		MaxTokens: int64(m.defaultMaxTokens),
 	}
@@ -437,7 +491,7 @@ func (m *anthropicModel) convertRequest(req *model.LLMRequest) (anthropic.Messag
 	if req.Config != nil {
 		thinkingCfg = req.Config.ThinkingConfig
 	}
-	mapping := converters.ThinkingConfigToAnthropic(thinkingCfg, params.Model)
+	mapping := converters.ThinkingConfigToAnthropic(thinkingCfg, m.name)
 	params.Thinking = mapping.Thinking
 	if mapping.Effort != "" {
 		params.OutputConfig.Effort = mapping.Effort

--- a/anthropic.go
+++ b/anthropic.go
@@ -47,8 +47,8 @@ const (
 
 type anthropicModel struct {
 	client anthropic.Client
-	// name is the canonical model used by Name and capability checks.
-	name anthropic.Model
+	// canonicalModel is exposed through Name and controls local capabilities.
+	canonicalModel anthropic.Model
 	// requestModel is the model identifier sent to the API.
 	requestModel     anthropic.Model
 	variant          string
@@ -127,7 +127,7 @@ func NewModel(ctx context.Context, modelName anthropic.Model, cfg *Config) (mode
 
 	return &anthropicModel{
 		client:           client,
-		name:             modelName,
+		canonicalModel:   modelName,
 		requestModel:     requestModel,
 		variant:          variant,
 		defaultMaxTokens: maxTokens,
@@ -175,14 +175,14 @@ func newVertexClient(ctx context.Context, cfg *Config) anthropic.Client {
 
 // Name returns the model name.
 func (m *anthropicModel) Name() string {
-	return string(m.name)
+	return string(m.canonicalModel)
 }
 
 func (m *anthropicModel) wireModel() anthropic.Model {
 	if m.requestModel != "" {
 		return m.requestModel
 	}
-	return m.name
+	return m.canonicalModel
 }
 
 // GenerateContent calls the Anthropic model.
@@ -459,7 +459,7 @@ func (m *anthropicModel) convertRequest(req *model.LLMRequest) (anthropic.Messag
 	if req.Config != nil {
 		thinkingCfg = req.Config.ThinkingConfig
 	}
-	mapping := converters.ThinkingConfigToAnthropic(thinkingCfg, m.name)
+	mapping := converters.ThinkingConfigToAnthropic(thinkingCfg, m.canonicalModel)
 	params.Thinking = mapping.Thinking
 	if mapping.Effort != "" {
 		params.OutputConfig.Effort = mapping.Effort

--- a/anthropic.go
+++ b/anthropic.go
@@ -33,12 +33,7 @@ import (
 	"google.golang.org/adk/v2/model"
 )
 
-const (
-	defaultMaxTokens          = 16384
-	defaultVercelGatewayURL   = "https://ai-gateway.vercel.sh"
-	vercelClaudeSonnet46Model = "anthropic/claude-sonnet-4.6"
-	vercelClaudeHaiku45Model  = "anthropic/claude-haiku-4.5"
-)
+const defaultMaxTokens = 16384
 
 // Mid-stream overload retry policy. Vertex AI can accept a streaming request
 // (HTTP 200 at the header level) and then deliver overloaded_error as an SSE
@@ -74,9 +69,9 @@ type anthropicModel struct {
 // For Vertex AI, set VertexProjectID and VertexLocation in the config or use
 // GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION environment variables.
 //
-// For Vercel AI Gateway, set VariantVercelAIGateway and provide its API key.
-// Canonical Claude aliases are translated to Vercel model IDs on the wire,
-// while Name continues to return the canonical model name.
+// For an Anthropic-compatible API, set BaseURL and APIKey. Set RequestModel
+// when the API expects a different model identifier from the canonical name.
+// Name and capability checks continue to use the canonical model name.
 func NewModel(ctx context.Context, modelName anthropic.Model, cfg *Config) (model.LLM, error) {
 	if cfg == nil {
 		cfg = &Config{}
@@ -108,11 +103,6 @@ func NewModel(ctx context.Context, modelName anthropic.Model, cfg *Config) (mode
 		}
 
 		client = newVertexClient(ctx, cfg)
-	case VariantVercelAIGateway:
-		if cfg.APIKey == "" {
-			return nil, errors.New("APIKey is required for Vercel AI Gateway")
-		}
-		client = newVercelGatewayClient(cfg)
 	case VariantAnthropicAPI:
 		client = newAPIClient(cfg)
 	default:
@@ -128,46 +118,20 @@ func NewModel(ctx context.Context, modelName anthropic.Model, cfg *Config) (mode
 		maxTokens = defaultMaxTokens
 	}
 
+	requestModel := cfg.RequestModel
+	if requestModel == "" {
+		requestModel = modelName
+	}
+
 	return &anthropicModel{
 		client:           client,
 		name:             modelName,
-		requestModel:     requestModelForVariant(modelName, variant),
+		requestModel:     requestModel,
 		variant:          variant,
 		defaultMaxTokens: maxTokens,
 		promptCaching:    cfg.PromptCaching,
 		retrySleep:       sleepWithContext,
 	}, nil
-}
-
-// newVercelGatewayClient creates a client for Vercel AI Gateway's
-// Anthropic-compatible API.
-func newVercelGatewayClient(cfg *Config) anthropic.Client {
-	return anthropic.NewClient(
-		option.WithAPIKey(cfg.APIKey),
-		option.WithBaseURL(vercelGatewayBaseURL(cfg)),
-	)
-}
-
-func vercelGatewayBaseURL(cfg *Config) string {
-	if cfg.BaseURL != "" {
-		return cfg.BaseURL
-	}
-	return defaultVercelGatewayURL
-}
-
-func requestModelForVariant(modelName anthropic.Model, variant string) anthropic.Model {
-	if variant != VariantVercelAIGateway {
-		return modelName
-	}
-
-	switch modelName {
-	case anthropic.ModelClaudeSonnet4_6:
-		return vercelClaudeSonnet46Model
-	case anthropic.ModelClaudeHaiku4_5:
-		return vercelClaudeHaiku45Model
-	default:
-		return modelName
-	}
 }
 
 // newAPIClient creates a client for the direct Anthropic API.

--- a/anthropic.go
+++ b/anthropic.go
@@ -46,8 +46,10 @@ const (
 )
 
 type anthropicModel struct {
-	client           anthropic.Client
-	name             anthropic.Model
+	client anthropic.Client
+	// name is the canonical model used by Name and capability checks.
+	name anthropic.Model
+	// requestModel is the model identifier sent to the API.
 	requestModel     anthropic.Model
 	variant          string
 	defaultMaxTokens int

--- a/anthropic.go
+++ b/anthropic.go
@@ -63,7 +63,7 @@ type anthropicModel struct {
 	retrySleep func(ctx context.Context, d time.Duration) error
 }
 
-// NewModel returns [model.LLM], backed by Anthropic Claude.
+// NewModel returns [model.LLM], backed by an Anthropic-compatible API.
 //
 // It creates an Anthropic client based on the provided configuration.
 // If Variant is not specified, it checks the ANTHROPIC_USE_VERTEX environment variable.
@@ -142,15 +142,17 @@ func NewModel(ctx context.Context, modelName anthropic.Model, cfg *Config) (mode
 // newVercelGatewayClient creates a client for Vercel AI Gateway's
 // Anthropic-compatible API.
 func newVercelGatewayClient(cfg *Config) anthropic.Client {
-	baseURL := cfg.BaseURL
-	if baseURL == "" {
-		baseURL = defaultVercelGatewayURL
-	}
-
 	return anthropic.NewClient(
 		option.WithAPIKey(cfg.APIKey),
-		option.WithBaseURL(baseURL),
+		option.WithBaseURL(vercelGatewayBaseURL(cfg)),
 	)
+}
+
+func vercelGatewayBaseURL(cfg *Config) string {
+	if cfg.BaseURL != "" {
+		return cfg.BaseURL
+	}
+	return defaultVercelGatewayURL
 }
 
 func requestModelForVariant(modelName anthropic.Model, variant string) anthropic.Model {

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -121,36 +121,6 @@ func TestNewModel_VertexAI_MissingConfig(t *testing.T) {
 	}
 }
 
-func TestNewModel_VercelAIGateway_MissingAPIKey(t *testing.T) {
-	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key-must-not-be-reused")
-
-	_, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, &Config{
-		Variant: VariantVercelAIGateway,
-	})
-	if err == nil || !strings.Contains(err.Error(), "APIKey is required for Vercel AI Gateway") {
-		t.Fatalf("NewModel() error = %v, want missing Vercel API key error", err)
-	}
-}
-
-func TestVercelGatewayBaseURL(t *testing.T) {
-	tests := []struct {
-		name string
-		cfg  *Config
-		want string
-	}{
-		{name: "default", cfg: &Config{}, want: "https://ai-gateway.vercel.sh"},
-		{name: "custom", cfg: &Config{BaseURL: "https://gateway.example.com"}, want: "https://gateway.example.com"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := vercelGatewayBaseURL(tt.cfg); got != tt.want {
-				t.Errorf("vercelGatewayBaseURL() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestNewModel_RejectsUnknownVariant(t *testing.T) {
 	_, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, &Config{
 		Variant: "UNKNOWN",
@@ -160,42 +130,34 @@ func TestNewModel_RejectsUnknownVariant(t *testing.T) {
 	}
 }
 
-func TestConvertRequest_VercelAIGatewayModelMapping(t *testing.T) {
+func TestConvertRequest_RequestModelOverride(t *testing.T) {
 	tests := []struct {
-		name          string
-		modelName     anthropic.Model
-		wantWireModel anthropic.Model
-		wantAdaptive  bool
+		name         string
+		requestModel anthropic.Model
+		wantModel    anthropic.Model
 	}{
 		{
-			name:          "sonnet_alias",
-			modelName:     anthropic.ModelClaudeSonnet4_6,
-			wantWireModel: vercelClaudeSonnet46Model,
-			wantAdaptive:  true,
+			name:      "uses canonical model by default",
+			wantModel: anthropic.ModelClaudeSonnet4_6,
 		},
 		{
-			name:          "haiku_alias",
-			modelName:     anthropic.ModelClaudeHaiku4_5,
-			wantWireModel: vercelClaudeHaiku45Model,
-		},
-		{
-			name:          "gateway_qualified_model_passes_through",
-			modelName:     "moonshotai/kimi-k3",
-			wantWireModel: "moonshotai/kimi-k3",
+			name:         "uses request model override",
+			requestModel: "provider/claude-sonnet-4.6",
+			wantModel:    "provider/claude-sonnet-4.6",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			llm, err := NewModel(t.Context(), tt.modelName, &Config{
-				APIKey:  "test-gateway-key",
-				Variant: VariantVercelAIGateway,
+			llm, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, &Config{
+				APIKey:       "test-api-key",
+				RequestModel: tt.requestModel,
 			})
 			if err != nil {
 				t.Fatalf("NewModel() error = %v", err)
 			}
-			if llm.Name() != string(tt.modelName) {
-				t.Errorf("Name() = %q, want canonical name %q", llm.Name(), tt.modelName)
+			if llm.Name() != string(anthropic.ModelClaudeSonnet4_6) {
+				t.Errorf("Name() = %q, want canonical name %q", llm.Name(), anthropic.ModelClaudeSonnet4_6)
 			}
 
 			params, err := llm.(*anthropicModel).convertRequest(&model.LLMRequest{
@@ -204,17 +166,17 @@ func TestConvertRequest_VercelAIGatewayModelMapping(t *testing.T) {
 			if err != nil {
 				t.Fatalf("convertRequest() error = %v", err)
 			}
-			if params.Model != tt.wantWireModel {
-				t.Errorf("request model = %q, want %q", params.Model, tt.wantWireModel)
+			if params.Model != tt.wantModel {
+				t.Errorf("request model = %q, want %q", params.Model, tt.wantModel)
 			}
-			if tt.wantAdaptive && params.Thinking.OfAdaptive == nil {
+			if params.Thinking.OfAdaptive == nil {
 				t.Error("expected canonical Sonnet name to retain adaptive thinking defaults")
 			}
 		})
 	}
 }
 
-func TestNewModel_VercelAIGatewayUsesConfiguredEndpointAndAPIKey(t *testing.T) {
+func TestNewModel_AnthropicCompatibleEndpointUsesConfiguredRequest(t *testing.T) {
 	type capturedRequest struct {
 		path   string
 		apiKey string
@@ -246,9 +208,9 @@ func TestNewModel_VercelAIGatewayUsesConfiguredEndpointAndAPIKey(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	llm, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, &Config{
-		APIKey:  "gateway-key",
-		Variant: VariantVercelAIGateway,
-		BaseURL: srv.URL,
+		APIKey:       "gateway-key",
+		BaseURL:      srv.URL,
+		RequestModel: "provider/claude-sonnet-4.6",
 	})
 	if err != nil {
 		t.Fatalf("NewModel() error = %v", err)
@@ -269,8 +231,8 @@ func TestNewModel_VercelAIGatewayUsesConfiguredEndpointAndAPIKey(t *testing.T) {
 	if got.apiKey != "gateway-key" {
 		t.Errorf("x-api-key = %q, want gateway-key", got.apiKey)
 	}
-	if got.model != vercelClaudeSonnet46Model {
-		t.Errorf("request model = %q, want %q", got.model, vercelClaudeSonnet46Model)
+	if got.model != "provider/claude-sonnet-4.6" {
+		t.Errorf("request model = %q, want %q", got.model, "provider/claude-sonnet-4.6")
 	}
 }
 

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -238,7 +238,7 @@ func TestNewModel_AnthropicCompatibleEndpointUsesConfiguredRequest(t *testing.T)
 
 func TestConvertRequest_VertexAI_SetsOutputConfig(t *testing.T) {
 	m := &anthropicModel{
-		name:             "claude-haiku-4-5-20251001",
+		canonicalModel:   "claude-haiku-4-5-20251001",
 		variant:          VariantVertexAI,
 		defaultMaxTokens: testMaxTokens,
 	}
@@ -273,7 +273,7 @@ func TestConvertRequest_VertexAI_SetsOutputConfig(t *testing.T) {
 
 func TestConvertRequest_OutputConfig_EnforcesAdditionalPropertiesFalse(t *testing.T) {
 	m := &anthropicModel{
-		name:             "claude-haiku-4-5-20251001",
+		canonicalModel:   "claude-haiku-4-5-20251001",
 		variant:          VariantVertexAI,
 		defaultMaxTokens: testMaxTokens,
 	}
@@ -330,7 +330,7 @@ func TestConvertRequest_OutputConfig_EnforcesAdditionalPropertiesFalse(t *testin
 
 func TestConvertRequest_VertexAI_TransformsUnsupportedSchemaConstraints(t *testing.T) {
 	m := &anthropicModel{
-		name:             "claude-haiku-4-5-20251001",
+		canonicalModel:   "claude-haiku-4-5-20251001",
 		variant:          VariantVertexAI,
 		defaultMaxTokens: testMaxTokens,
 	}
@@ -434,7 +434,7 @@ func assertAdditionalPropertiesFalse(t *testing.T, schema map[string]any, label 
 
 func TestConvertRequest_OutputConfig_EnforcesAdditionalPropertiesFalse_AnyOf(t *testing.T) {
 	m := &anthropicModel{
-		name:             "claude-haiku-4-5-20251001",
+		canonicalModel:   "claude-haiku-4-5-20251001",
 		variant:          VariantVertexAI,
 		defaultMaxTokens: testMaxTokens,
 	}
@@ -487,7 +487,7 @@ func TestConvertRequest_OutputConfig_EnforcesAdditionalPropertiesFalse_AnyOf(t *
 
 func TestConvertRequest_DirectAPI_SetsOutputConfig(t *testing.T) {
 	m := &anthropicModel{
-		name:             "claude-haiku-4-5-20251001",
+		canonicalModel:   "claude-haiku-4-5-20251001",
 		variant:          VariantAnthropicAPI,
 		defaultMaxTokens: testMaxTokens,
 	}
@@ -556,7 +556,7 @@ func TestConvertRequest_DefaultsToAdaptiveOnCapableModel(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			m := &anthropicModel{
 				// Adaptive-capable model — unversioned SDK alias.
-				name:             "claude-sonnet-4-6",
+				canonicalModel:   "claude-sonnet-4-6",
 				variant:          VariantAnthropicAPI,
 				defaultMaxTokens: testMaxTokens,
 			}
@@ -567,7 +567,7 @@ func TestConvertRequest_DefaultsToAdaptiveOnCapableModel(t *testing.T) {
 			}
 
 			if params.Thinking.OfAdaptive == nil {
-				t.Fatalf("expected adaptive thinking on %s, got Thinking=%+v", m.name, params.Thinking)
+				t.Fatalf("expected adaptive thinking on %s, got Thinking=%+v", m.canonicalModel, params.Thinking)
 			}
 		})
 	}
@@ -581,7 +581,7 @@ func TestConvertRequest_DefaultsToAdaptiveOnCapableModel(t *testing.T) {
 func TestConvertRequest_NilConfigLeavesThinkingOffOnNonAdaptive(t *testing.T) {
 	m := &anthropicModel{
 		// Manual-only model — adaptive is not supported.
-		name:             "claude-haiku-4-5",
+		canonicalModel:   "claude-haiku-4-5",
 		variant:          VariantAnthropicAPI,
 		defaultMaxTokens: testMaxTokens,
 	}
@@ -598,10 +598,10 @@ func TestConvertRequest_NilConfigLeavesThinkingOffOnNonAdaptive(t *testing.T) {
 	}
 
 	if params.Thinking.OfAdaptive != nil {
-		t.Errorf("non-adaptive model %s should not default to adaptive thinking, got OfAdaptive=%+v", m.name, params.Thinking.OfAdaptive)
+		t.Errorf("non-adaptive model %s should not default to adaptive thinking, got OfAdaptive=%+v", m.canonicalModel, params.Thinking.OfAdaptive)
 	}
 	if params.Thinking.OfEnabled != nil {
-		t.Errorf("non-adaptive model %s should not default to manual thinking budget, got OfEnabled=%+v", m.name, params.Thinking.OfEnabled)
+		t.Errorf("non-adaptive model %s should not default to manual thinking budget, got OfEnabled=%+v", m.canonicalModel, params.Thinking.OfEnabled)
 	}
 }
 
@@ -700,7 +700,7 @@ func TestConvertRequest_ForcedToolUseDropsThinking(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			m := &anthropicModel{
-				name:             tc.modelName,
+				canonicalModel:   tc.modelName,
 				variant:          VariantAnthropicAPI,
 				defaultMaxTokens: testMaxTokens,
 			}
@@ -768,7 +768,7 @@ func TestConvertRequest_AutoToolUseKeepsThinking(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			m := &anthropicModel{
-				name:             "claude-sonnet-4-6",
+				canonicalModel:   "claude-sonnet-4-6",
 				variant:          VariantAnthropicAPI,
 				defaultMaxTokens: testMaxTokens,
 			}

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -132,6 +132,25 @@ func TestNewModel_VercelAIGateway_MissingAPIKey(t *testing.T) {
 	}
 }
 
+func TestVercelGatewayBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want string
+	}{
+		{name: "default", cfg: &Config{}, want: defaultVercelGatewayURL},
+		{name: "custom", cfg: &Config{BaseURL: "https://gateway.example.com"}, want: "https://gateway.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := vercelGatewayBaseURL(tt.cfg); got != tt.want {
+				t.Errorf("vercelGatewayBaseURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewModel_RejectsUnknownVariant(t *testing.T) {
 	_, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, &Config{
 		Variant: "UNKNOWN",

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -151,6 +151,7 @@ func TestConvertRequest_RequestModelOverride(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			llm, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, &Config{
 				APIKey:       "test-api-key",
+				Variant:      VariantAnthropicAPI,
 				RequestModel: tt.requestModel,
 			})
 			if err != nil {
@@ -209,6 +210,7 @@ func TestNewModel_AnthropicCompatibleEndpointUsesConfiguredRequest(t *testing.T)
 
 	llm, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, &Config{
 		APIKey:       "gateway-key",
+		Variant:      VariantAnthropicAPI,
 		BaseURL:      srv.URL,
 		RequestModel: "provider/claude-sonnet-4.6",
 	})

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -15,6 +15,10 @@
 package adkanthropic
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -114,6 +118,140 @@ func TestNewModel_VertexAI_MissingConfig(t *testing.T) {
 				t.Fatalf("NewModel() error = %v, want contains %q", err, tt.wantError)
 			}
 		})
+	}
+}
+
+func TestNewModel_VercelAIGateway_MissingAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key-must-not-be-reused")
+
+	_, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, &Config{
+		Variant: VariantVercelAIGateway,
+	})
+	if err == nil || !strings.Contains(err.Error(), "APIKey is required for Vercel AI Gateway") {
+		t.Fatalf("NewModel() error = %v, want missing Vercel API key error", err)
+	}
+}
+
+func TestNewModel_RejectsUnknownVariant(t *testing.T) {
+	_, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, &Config{
+		Variant: "UNKNOWN",
+	})
+	if err == nil || !strings.Contains(err.Error(), `unsupported Anthropic variant "UNKNOWN"`) {
+		t.Fatalf("NewModel() error = %v, want unsupported variant error", err)
+	}
+}
+
+func TestConvertRequest_VercelAIGatewayModelMapping(t *testing.T) {
+	tests := []struct {
+		name          string
+		modelName     anthropic.Model
+		wantWireModel anthropic.Model
+		wantAdaptive  bool
+	}{
+		{
+			name:          "sonnet_alias",
+			modelName:     anthropic.ModelClaudeSonnet4_6,
+			wantWireModel: vercelClaudeSonnet46Model,
+			wantAdaptive:  true,
+		},
+		{
+			name:          "haiku_alias",
+			modelName:     anthropic.ModelClaudeHaiku4_5,
+			wantWireModel: vercelClaudeHaiku45Model,
+		},
+		{
+			name:          "gateway_qualified_model_passes_through",
+			modelName:     "moonshotai/kimi-k3",
+			wantWireModel: "moonshotai/kimi-k3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			llm, err := NewModel(t.Context(), tt.modelName, &Config{
+				APIKey:  "test-gateway-key",
+				Variant: VariantVercelAIGateway,
+			})
+			if err != nil {
+				t.Fatalf("NewModel() error = %v", err)
+			}
+			if llm.Name() != string(tt.modelName) {
+				t.Errorf("Name() = %q, want canonical name %q", llm.Name(), tt.modelName)
+			}
+
+			params, err := llm.(*anthropicModel).convertRequest(&model.LLMRequest{
+				Contents: []*genai.Content{genai.NewContentFromText("Hello", "user")},
+			})
+			if err != nil {
+				t.Fatalf("convertRequest() error = %v", err)
+			}
+			if params.Model != tt.wantWireModel {
+				t.Errorf("request model = %q, want %q", params.Model, tt.wantWireModel)
+			}
+			if tt.wantAdaptive && params.Thinking.OfAdaptive == nil {
+				t.Error("expected canonical Sonnet name to retain adaptive thinking defaults")
+			}
+		})
+	}
+}
+
+func TestNewModel_VercelAIGatewayUsesConfiguredEndpointAndAPIKey(t *testing.T) {
+	type capturedRequest struct {
+		path   string
+		apiKey string
+		model  string
+	}
+	captured := make(chan capturedRequest, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		var requestBody struct {
+			Model string `json:"model"`
+		}
+		if err := json.Unmarshal(body, &requestBody); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		captured <- capturedRequest{
+			path:   r.URL.Path,
+			apiKey: r.Header.Get("x-api-key"),
+			model:  requestBody.Model,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_1","type":"message","role":"assistant","model":"anthropic/claude-sonnet-4.6","content":[{"type":"text","text":"Hello"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	llm, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, &Config{
+		APIKey:  "gateway-key",
+		Variant: VariantVercelAIGateway,
+		BaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewModel() error = %v", err)
+	}
+
+	for _, err := range llm.GenerateContent(t.Context(), &model.LLMRequest{
+		Contents: []*genai.Content{genai.NewContentFromText("Hello", "user")},
+	}, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent() error = %v", err)
+		}
+	}
+
+	got := <-captured
+	if got.path != "/v1/messages" {
+		t.Errorf("request path = %q, want /v1/messages", got.path)
+	}
+	if got.apiKey != "gateway-key" {
+		t.Errorf("x-api-key = %q, want gateway-key", got.apiKey)
+	}
+	if got.model != vercelClaudeSonnet46Model {
+		t.Errorf("request model = %q, want %q", got.model, vercelClaudeSonnet46Model)
 	}
 }
 

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -138,7 +138,7 @@ func TestVercelGatewayBaseURL(t *testing.T) {
 		cfg  *Config
 		want string
 	}{
-		{name: "default", cfg: &Config{}, want: defaultVercelGatewayURL},
+		{name: "default", cfg: &Config{}, want: "https://ai-gateway.vercel.sh"},
 		{name: "custom", cfg: &Config{BaseURL: "https://gateway.example.com"}, want: "https://gateway.example.com"},
 	}
 

--- a/config.go
+++ b/config.go
@@ -43,12 +43,11 @@ type PromptCachingConfig struct {
 	ConversationHistory *CacheBreakpoint
 }
 
-// Config holds configuration for creating a model through an Anthropic-compatible backend.
+// Config holds configuration for creating an Anthropic model.
 type Config struct {
-	// APIKey authenticates requests to the selected API backend.
+	// APIKey authenticates requests to the direct or Anthropic-compatible API.
 	// If not provided, it will be read from the ANTHROPIC_API_KEY environment variable.
-	// Environment fallback is only used when Variant is VariantAnthropicAPI.
-	// VariantVercelAIGateway requires an explicit API key.
+	// This is only used when Variant is VariantAnthropicAPI.
 	APIKey string
 
 	// VertexProjectID is the Google Cloud project ID for Vertex AI access.
@@ -63,7 +62,7 @@ type Config struct {
 	VertexLocation string
 
 	// Variant determines which backend to use for API calls.
-	// Valid values are VariantAnthropicAPI, VariantVertexAI, and VariantVercelAIGateway.
+	// Valid values are VariantAnthropicAPI and VariantVertexAI.
 	// If empty, the variant is determined from the ANTHROPIC_USE_VERTEX environment variable.
 	Variant string
 
@@ -75,9 +74,15 @@ type Config struct {
 	// GenerateContentConfig.MaxOutputTokens override.
 	DefaultMaxTokens int
 
-	// BaseURL overrides the API endpoint. VariantVercelAIGateway defaults to
-	// https://ai-gateway.vercel.sh when this is empty.
+	// BaseURL overrides the direct Anthropic API endpoint. This supports proxies
+	// and Anthropic-compatible APIs. It is ignored for Vertex AI.
 	BaseURL string
+
+	// RequestModel overrides the model identifier sent to the API. This lets a
+	// caller retain the canonical model name for Name and capability checks while
+	// using a provider-qualified identifier on an Anthropic-compatible API.
+	// When empty, the model passed to NewModel is sent unchanged.
+	RequestModel anthropic.Model
 
 	// PromptCaching configures optional prompt caching breakpoints.
 	// When nil (the default), no cache control is applied.

--- a/config.go
+++ b/config.go
@@ -45,9 +45,10 @@ type PromptCachingConfig struct {
 
 // Config holds configuration for creating an Anthropic Claude model.
 type Config struct {
-	// APIKey is the Anthropic API key for direct API access.
+	// APIKey authenticates requests to the selected API backend.
 	// If not provided, it will be read from the ANTHROPIC_API_KEY environment variable.
-	// This is only used when Variant is VariantAnthropicAPI.
+	// Environment fallback is only used when Variant is VariantAnthropicAPI.
+	// VariantVercelAIGateway requires an explicit API key.
 	APIKey string
 
 	// VertexProjectID is the Google Cloud project ID for Vertex AI access.
@@ -62,7 +63,7 @@ type Config struct {
 	VertexLocation string
 
 	// Variant determines which backend to use for API calls.
-	// Valid values are VariantAnthropicAPI and VariantVertexAI.
+	// Valid values are VariantAnthropicAPI, VariantVertexAI, and VariantVercelAIGateway.
 	// If empty, the variant is determined from the ANTHROPIC_USE_VERTEX environment variable.
 	Variant string
 
@@ -74,6 +75,8 @@ type Config struct {
 	// GenerateContentConfig.MaxOutputTokens override.
 	DefaultMaxTokens int
 
+	// BaseURL overrides the API endpoint. VariantVercelAIGateway defaults to
+	// https://ai-gateway.vercel.sh when this is empty.
 	BaseURL string
 
 	// PromptCaching configures optional prompt caching breakpoints.

--- a/config.go
+++ b/config.go
@@ -43,7 +43,7 @@ type PromptCachingConfig struct {
 	ConversationHistory *CacheBreakpoint
 }
 
-// Config holds configuration for creating an Anthropic Claude model.
+// Config holds configuration for creating a model through an Anthropic-compatible backend.
 type Config struct {
 	// APIKey authenticates requests to the selected API backend.
 	// If not provided, it will be read from the ANTHROPIC_API_KEY environment variable.

--- a/doc.go
+++ b/doc.go
@@ -15,8 +15,8 @@
 // Package adkanthropic implements the [model.LLM] interface for Anthropic Claude models
 // for use with Google's Agent Development Kit (ADK).
 //
-// This package provides support for both the direct Anthropic API and
-// Anthropic models via Google Cloud Vertex AI.
+// This package provides support for the direct Anthropic API, Anthropic models
+// via Google Cloud Vertex AI, and Vercel AI Gateway's Anthropic-compatible API.
 //
 // # Installation
 //
@@ -56,6 +56,18 @@
 //
 // Alternatively, set the ANTHROPIC_USE_VERTEX environment variable to "1" or "true"
 // to automatically use Vertex AI without specifying the variant in code.
+//
+// # Vercel AI Gateway Usage
+//
+// To use Vercel AI Gateway:
+//
+//	model, err := adkanthropic.NewModel(ctx, anthropic.ModelClaudeSonnet4_6, &adkanthropic.Config{
+//		APIKey:  os.Getenv("AI_GATEWAY_API_KEY"),
+//		Variant: adkanthropic.VariantVercelAIGateway,
+//	})
+//
+// The adapter keeps the canonical Anthropic model name for capability checks
+// and maps supported Claude aliases to Vercel's creator/model format on the wire.
 //
 // # Supported Models
 //

--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@
 // for use with Google's Agent Development Kit (ADK).
 //
 // This package provides support for the direct Anthropic API, Anthropic models
-// via Google Cloud Vertex AI, and Vercel AI Gateway's Anthropic-compatible API.
+// via Google Cloud Vertex AI, and Anthropic-compatible APIs.
 //
 // # Installation
 //
@@ -57,17 +57,18 @@
 // Alternatively, set the ANTHROPIC_USE_VERTEX environment variable to "1" or "true"
 // to automatically use Vertex AI without specifying the variant in code.
 //
-// # Vercel AI Gateway Usage
+// # Anthropic-Compatible API Usage
 //
-// To use Vercel AI Gateway:
+// To use an Anthropic-compatible API while retaining the canonical model name:
 //
 //	model, err := adkanthropic.NewModel(ctx, anthropic.ModelClaudeSonnet4_6, &adkanthropic.Config{
-//		APIKey:  os.Getenv("AI_GATEWAY_API_KEY"),
-//		Variant: adkanthropic.VariantVercelAIGateway,
+//		APIKey:       os.Getenv("GATEWAY_API_KEY"),
+//		BaseURL:      "https://gateway.example.com",
+//		RequestModel: "provider/claude-sonnet-4.6",
 //	})
 //
-// The adapter keeps the canonical Anthropic model name for capability checks
-// and maps supported Claude aliases to Vercel's creator/model format on the wire.
+// The adapter uses RequestModel only for API requests. Name and capability
+// checks continue to use the canonical model passed to NewModel.
 //
 // # Supported Models
 //

--- a/variant.go
+++ b/variant.go
@@ -27,9 +27,6 @@ const (
 
 	// VariantVertexAI uses Anthropic models via Google Cloud Vertex AI.
 	VariantVertexAI = "VERTEX_AI"
-
-	// VariantVercelAIGateway uses Vercel AI Gateway's Anthropic-compatible API.
-	VariantVercelAIGateway = "VERCEL_AI_GATEWAY"
 )
 
 // GetVariant returns the configured variant for the Anthropic backend.

--- a/variant.go
+++ b/variant.go
@@ -27,6 +27,9 @@ const (
 
 	// VariantVertexAI uses Anthropic models via Google Cloud Vertex AI.
 	VariantVertexAI = "VERTEX_AI"
+
+	// VariantVercelAIGateway uses Vercel AI Gateway's Anthropic-compatible API.
+	VariantVercelAIGateway = "VERCEL_AI_GATEWAY"
 )
 
 // GetVariant returns the configured variant for the Anthropic backend.


### PR DESCRIPTION
## Problem

The adapter supports custom Anthropic-compatible endpoints, but one model name currently controls both local capability checks and the identifier sent to the API. Gateways that require provider-qualified model IDs cannot preserve the canonical Anthropic model name.

## Solution

Add an optional `Config.RequestModel` override for the identifier sent to the API. `Name()` and capability checks continue to use the canonical model passed to `NewModel`, while callers retain ownership of gateway URLs, credentials, and model mapping.