### PR TITLE
Preserve Anthropic cache creation usage

### DIFF
--- a/converters/converters_test.go
+++ b/converters/converters_test.go
@@ -1300,6 +1300,50 @@ func TestMessageToLLMResponse_SetsModelVersion(t *testing.T) {
 	}
 }
 
+func TestMessageToLLMResponse_CacheCreationMetadata(t *testing.T) {
+	t.Run("populated cache creation usage", func(t *testing.T) {
+		msg := &anthropic.Message{
+			Usage: anthropic.Usage{
+				CacheCreationInputTokens: 60,
+				CacheCreation: anthropic.CacheCreation{
+					Ephemeral5mInputTokens: 40,
+					Ephemeral1hInputTokens: 20,
+				},
+			},
+		}
+
+		resp, err := converters.MessageToLLMResponse(msg)
+		if err != nil {
+			t.Fatalf("MessageToLLMResponse() error = %v", err)
+		}
+
+		want := map[string]any{
+			"anthropic.usage.cache_creation_input_tokens":    int64(60),
+			"anthropic.usage.cache_creation_5m_input_tokens": int64(40),
+			"anthropic.usage.cache_creation_1h_input_tokens": int64(20),
+		}
+		if diff := cmp.Diff(want, resp.CustomMetadata); diff != "" {
+			t.Errorf("CustomMetadata mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("zero values remain present", func(t *testing.T) {
+		resp, err := converters.MessageToLLMResponse(&anthropic.Message{})
+		if err != nil {
+			t.Fatalf("MessageToLLMResponse() error = %v", err)
+		}
+
+		want := map[string]any{
+			"anthropic.usage.cache_creation_input_tokens":    int64(0),
+			"anthropic.usage.cache_creation_5m_input_tokens": int64(0),
+			"anthropic.usage.cache_creation_1h_input_tokens": int64(0),
+		}
+		if diff := cmp.Diff(want, resp.CustomMetadata); diff != "" {
+			t.Errorf("CustomMetadata mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
 func TestContentBlockToGenaiPart_WebSearchToolResult(t *testing.T) {
 	blockJSON := `{
 		"type": "web_search_tool_result",

--- a/converters/response.go
+++ b/converters/response.go
@@ -25,7 +25,15 @@ import (
 	"google.golang.org/adk/v2/model"
 )
 
+const (
+	cacheCreationInputTokensMetadataKey   = "anthropic.usage.cache_creation_input_tokens"
+	cacheCreation5mInputTokensMetadataKey = "anthropic.usage.cache_creation_5m_input_tokens"
+	cacheCreation1hInputTokensMetadataKey = "anthropic.usage.cache_creation_1h_input_tokens"
+)
+
 // MessageToLLMResponse converts an Anthropic Message to a model.LLMResponse.
+// Both non-streaming replies and final accumulated streaming replies use this
+// converter, so usage metadata has the same contract on both paths.
 func MessageToLLMResponse(msg *anthropic.Message) (*model.LLMResponse, error) {
 	if msg == nil {
 		return nil, fmt.Errorf("nil message received")
@@ -54,10 +62,11 @@ func MessageToLLMResponse(msg *anthropic.Message) (*model.LLMResponse, error) {
 	}
 
 	resp := &model.LLMResponse{
-		Content:       content,
-		UsageMetadata: UsageToMetadata(msg.Usage),
-		FinishReason:  StopReasonToFinishReason(msg.StopReason),
-		ModelVersion:  string(msg.Model),
+		Content:        content,
+		UsageMetadata:  UsageToMetadata(msg.Usage),
+		CustomMetadata: usageToCustomMetadata(msg.Usage),
+		FinishReason:   StopReasonToFinishReason(msg.StopReason),
+		ModelVersion:   string(msg.Model),
 	}
 
 	if len(allCitations) > 0 {
@@ -65,6 +74,14 @@ func MessageToLLMResponse(msg *anthropic.Message) (*model.LLMResponse, error) {
 	}
 
 	return resp, nil
+}
+
+func usageToCustomMetadata(usage anthropic.Usage) map[string]any {
+	return map[string]any{
+		cacheCreationInputTokensMetadataKey:   usage.CacheCreationInputTokens,
+		cacheCreation5mInputTokensMetadataKey: usage.CacheCreation.Ephemeral5mInputTokens,
+		cacheCreation1hInputTokensMetadataKey: usage.CacheCreation.Ephemeral1hInputTokens,
+	}
 }
 
 // InterruptedContent holds what could be salvaged from a message whose


### PR DESCRIPTION
## Problem

Anthropic cache creation usage is lost when messages are converted to ADK responses, so downstream evaluation cost reports cannot distinguish cache writes from normal input tokens. Tracked in [AI-2187](https://linear.app/alcova/issue/AI-2187/preserve-complete-anthropic-cache-usage-for-skill-eval-costs).

## Solution

Add the aggregate, five-minute, and one-hour cache creation token counts to `LLMResponse.CustomMetadata`. The common final-response converter applies the same metadata to streaming and non-streaming replies, including stable zero values.
