### PR TITLE
Support Gemini through Anthropic-compatible gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v2.0.10] - Support Gemini gateway compatibility
+
+- Preserve multi-type JSON Schema definitions as Anthropic `anyOf` schemas so gateway-routed Gemini tool requests retain each allowed type.
+- Respect `IncludeThoughts: false` when Anthropic-compatible gateways return unsigned Gemini reasoning. Signed and redacted provider state remains unchanged so callers can include it in later requests.
+
 ## [v2.0.9] - Add request model overrides
 
 - Add `Config.RequestModel` for Anthropic-compatible APIs that require a different model identifier on the wire. Capability checks and `Name()` continue to use the canonical model passed to `NewModel`.

--- a/anthropic.go
+++ b/anthropic.go
@@ -215,8 +215,36 @@ func (m *anthropicModel) generate(ctx context.Context, req *model.LLMRequest) (*
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert response: %w", err)
 	}
+	filterResponseThoughts(resp, requestIncludesThoughts(req))
 
 	return resp, nil
+}
+
+func requestIncludesThoughts(req *model.LLMRequest) bool {
+	return req != nil && req.Config != nil && req.Config.ThinkingConfig != nil &&
+		req.Config.ThinkingConfig.IncludeThoughts
+}
+
+// filterResponseThoughts enforces IncludeThoughts on providers that do not.
+// Vercel's Anthropic-compatible endpoint can return unsigned Gemini reasoning
+// blocks even when thinking.display is "omitted". Those blocks are display-only
+// and safe to discard. Signed thinking and redacted metadata are provider state
+// that must be replayed unchanged on later requests, so they are always kept.
+func filterResponseThoughts(resp *model.LLMResponse, includeThoughts bool) {
+	if includeThoughts || resp == nil || resp.Content == nil {
+		return
+	}
+	resp.Content.Parts = filterThoughtParts(resp.Content.Parts)
+}
+
+func filterThoughtParts(parts []*genai.Part) []*genai.Part {
+	filtered := make([]*genai.Part, 0, len(parts))
+	for _, part := range parts {
+		if part == nil || !part.Thought || len(part.ThoughtSignature) > 0 || len(part.PartMetadata) > 0 {
+			filtered = append(filtered, part)
+		}
+	}
+	return filtered
 }
 
 // generateStream returns a stream of responses from the model.
@@ -234,8 +262,9 @@ func (m *anthropicModel) generateStream(ctx context.Context, req *model.LLMReque
 		// returns nil. This is a deliberate, narrow exception to the adapter's
 		// "no continuation decisions" rule — a pre-content retry is invisible
 		// to callers and carries no continuation semantics.
+		includeThoughts := requestIncludesThoughts(req)
 		for attempt := 1; ; attempt++ {
-			streamErr := m.streamOnce(ctx, params, yield)
+			streamErr := m.streamOnce(ctx, params, includeThoughts, yield)
 			if streamErr == nil {
 				return
 			}
@@ -263,7 +292,12 @@ func (m *anthropicModel) generateStream(ctx context.Context, req *model.LLMReque
 // generateStream may safely retry without duplicating output. Every other
 // outcome (success, consumer stop, post-content failure, interruption) is
 // fully handled here and signalled by a nil return.
-func (m *anthropicModel) streamOnce(ctx context.Context, params anthropic.MessageNewParams, yield func(*model.LLMResponse, error) bool) error {
+func (m *anthropicModel) streamOnce(
+	ctx context.Context,
+	params anthropic.MessageNewParams,
+	includeThoughts bool,
+	yield func(*model.LLMResponse, error) bool,
+) error {
 	stream := m.client.Messages.NewStreaming(ctx, params)
 	// Next() leaves the response body open on the SSE error-event and
 	// consumer-stop paths; without this, each retried attempt would leak its
@@ -287,7 +321,7 @@ func (m *anthropicModel) streamOnce(ctx context.Context, params anthropic.Messag
 		// accumulation failure keeps its original error so it isn't
 		// misdiagnosed as an interruption.
 		if err := message.Accumulate(event); err != nil {
-			yield(nil, classifyAccumulateError(&message, err))
+			yield(nil, classifyAccumulateError(&message, err, includeThoughts))
 			return nil
 		}
 
@@ -303,6 +337,11 @@ func (m *anthropicModel) streamOnce(ctx context.Context, params anthropic.Messag
 					return nil
 				}
 			case anthropic.ThinkingDelta:
+				if !includeThoughts {
+					// The signature arrives in a later delta and is retained from the
+					// final accumulated block. Do not expose provisional reasoning text.
+					continue
+				}
 				yielded = true
 				resp := converters.StreamThinkingDeltaToPartialResponse(delta.Thinking)
 				if !yield(resp, nil) {
@@ -329,7 +368,7 @@ func (m *anthropicModel) streamOnce(ctx context.Context, params anthropic.Messag
 	// interruption for our purposes — it converts normally below and the
 	// harness reacts off the mapped max_tokens FinishReason.
 	if message.StopReason == anthropic.StopReasonMaxTokens && converters.HasIncompleteToolInput(&message) {
-		yield(nil, newOutputInterruptedError(&message, nil))
+		yield(nil, newOutputInterruptedError(&message, nil, includeThoughts))
 		return nil
 	}
 
@@ -339,6 +378,7 @@ func (m *anthropicModel) streamOnce(ctx context.Context, params anthropic.Messag
 		yield(nil, fmt.Errorf("failed to convert stream response: %w", err))
 		return nil
 	}
+	filterResponseThoughts(finalResp, includeThoughts)
 	finalResp.TurnComplete = true
 	yield(finalResp, nil)
 	return nil

--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -238,6 +238,82 @@ func TestNewModel_AnthropicCompatibleEndpointUsesConfiguredRequest(t *testing.T)
 	}
 }
 
+func TestFilterThoughtParts_PreservesProviderState(t *testing.T) {
+	unsigned := &genai.Part{Thought: true, Text: "Vercel Gemini reasoning"}
+	signed := &genai.Part{Thought: true, Text: "signed reasoning", ThoughtSignature: []byte("sig")}
+	redacted := &genai.Part{
+		Thought:      true,
+		Text:         "[thinking redacted]",
+		PartMetadata: map[string]any{"anthropic.redacted_thinking_data": "opaque"},
+	}
+	text := &genai.Part{Text: "answer"}
+
+	got := filterThoughtParts([]*genai.Part{unsigned, signed, redacted, text})
+
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3", len(got))
+	}
+	if got[0] != signed || got[0].Text != "signed reasoning" {
+		t.Errorf("got[0] = %+v, want signed thinking preserved unchanged", got[0])
+	}
+	if got[1] != redacted {
+		t.Errorf("got[1] = %+v, want redacted provider state preserved", got[1])
+	}
+	if got[2] != text {
+		t.Errorf("got[2] = %+v, want answer text", got[2])
+	}
+}
+
+func TestGenerateContent_HonoursIncludeThoughts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_1","type":"message","role":"assistant","model":"google/gemini-3.6-flash","content":[{"type":"thinking","thinking":"Vercel Gemini reasoning","signature":""},{"type":"text","text":"Hello"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":2}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	llm, err := NewModel(t.Context(), anthropic.ModelClaudeSonnet4_6, &Config{
+		APIKey:  "gateway-key",
+		Variant: VariantAnthropicAPI,
+		BaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewModel() error = %v", err)
+	}
+
+	for _, tc := range []struct {
+		name            string
+		includeThoughts bool
+		wantParts       int
+	}{
+		{name: "hidden", includeThoughts: false, wantParts: 1},
+		{name: "included", includeThoughts: true, wantParts: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &model.LLMRequest{Config: &genai.GenerateContentConfig{
+				ThinkingConfig: &genai.ThinkingConfig{IncludeThoughts: tc.includeThoughts},
+			}}
+
+			var got *model.LLMResponse
+			for resp, err := range llm.GenerateContent(t.Context(), req, false) {
+				if err != nil {
+					t.Fatalf("GenerateContent() error = %v", err)
+				}
+				got = resp
+			}
+
+			if got == nil || got.Content == nil {
+				t.Fatal("GenerateContent() returned no content")
+			}
+			if len(got.Content.Parts) != tc.wantParts {
+				t.Fatalf("len(got.Content.Parts) = %d, want %d", len(got.Content.Parts), tc.wantParts)
+			}
+			if got.Content.Parts[len(got.Content.Parts)-1].Text != "Hello" {
+				t.Errorf("last part = %+v, want answer text", got.Content.Parts[len(got.Content.Parts)-1])
+			}
+		})
+	}
+}
+
 func TestConvertRequest_VertexAI_SetsOutputConfig(t *testing.T) {
 	m := &anthropicModel{
 		canonicalModel:   "claude-haiku-4-5-20251001",

--- a/converters/converters_test.go
+++ b/converters/converters_test.go
@@ -923,6 +923,49 @@ func TestFunctionDeclarationToTool_JsonSchemaNoRequired(t *testing.T) {
 	}
 }
 
+func TestFunctionDeclarationToTool_JsonSchemaMultipleTypesUsesAnyOf(t *testing.T) {
+	type todoItem struct {
+		Content string `json:"content"`
+	}
+	type todoWriteInput struct {
+		Todos []todoItem `json:"todos" jsonschema:"list of todo items to create or update"`
+	}
+
+	schema, err := jsonschema.For[todoWriteInput](nil)
+	if err != nil {
+		t.Fatalf("jsonschema.For[todoWriteInput]() failed: %v", err)
+	}
+
+	result := converters.FunctionDeclarationToTool(&genai.FunctionDeclaration{
+		Name:                 "todo_write",
+		ParametersJsonSchema: schema,
+	})
+	properties, ok := result.OfTool.InputSchema.Properties.(map[string]any)
+	if !ok {
+		t.Fatalf("expected Properties to be map[string]any, got %T", result.OfTool.InputSchema.Properties)
+	}
+
+	want := map[string]any{
+		"anyOf": []map[string]any{
+			{"type": "null"},
+			{
+				"type":        "array",
+				"description": "list of todo items to create or update",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"content": map[string]any{"type": "string"},
+					},
+					"required": []string{"content"},
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(want, properties["todos"]); diff != "" {
+		t.Errorf("todos schema mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestFunctionDeclarationToTool_ParametersJsonSchemaMap(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/converters/tools.go
+++ b/converters/tools.go
@@ -138,11 +138,32 @@ func jsonSchemaPropertyToMap(schema *jsonschema.Schema) map[string]any {
 		return nil
 	}
 
-	result := make(map[string]any)
+	if len(schema.Types) > 0 {
+		anyOf := make([]map[string]any, 0, len(schema.Types))
+		for _, schemaType := range schema.Types {
+			branch := map[string]any{"type": schemaType}
+			if schemaType != "null" {
+				branch = jsonSchemaPropertyFieldsToMap(schema)
+				branch["type"] = schemaType
+			}
+			anyOf = append(anyOf, branch)
+		}
+		return map[string]any{"anyOf": anyOf}
+	}
+
+	result := jsonSchemaPropertyFieldsToMap(schema)
 
 	if schema.Type != "" {
 		result["type"] = string(schema.Type)
 	}
+
+	return result
+}
+
+// jsonSchemaPropertyFieldsToMap converts fields shared by a schema's possible types.
+func jsonSchemaPropertyFieldsToMap(schema *jsonschema.Schema) map[string]any {
+	result := make(map[string]any)
+
 	if schema.Description != "" {
 		result["description"] = schema.Description
 	}

--- a/errors.go
+++ b/errors.go
@@ -38,9 +38,10 @@ type OutputInterruptedError struct {
 	StopReason anthropic.StopReason
 
 	// Parts holds the salvaged content that survived intact, converted to
-	// genai parts in stream order: thinking parts (with signatures) and any
-	// completed text or tool-call parts. The truncated tool call is NOT
-	// included here — it is exposed as data via ToolName/PartialInput.
+	// genai parts in stream order: signed or redacted provider-state thoughts,
+	// visible thoughts when requested, and any completed text or tool-call
+	// parts. The truncated tool call is NOT included here — it is exposed as
+	// data via ToolName/PartialInput.
 	Parts []*genai.Part
 
 	// ToolName is the name of the tool call whose input was cut off, if the
@@ -77,8 +78,11 @@ func (e *OutputInterruptedError) Unwrap() error { return e.Cause }
 // tool call's details. cause is the underlying error that surfaced the
 // interruption (the SDK accumulator failure), or nil when the interruption was
 // detected directly from the stop reason.
-func newOutputInterruptedError(msg *anthropic.Message, cause error) *OutputInterruptedError {
+func newOutputInterruptedError(msg *anthropic.Message, cause error, includeThoughts bool) *OutputInterruptedError {
 	salvaged := converters.SalvageInterruptedMessage(msg)
+	if !includeThoughts {
+		salvaged.Parts = filterThoughtParts(salvaged.Parts)
+	}
 
 	var stopReason anthropic.StopReason
 	if msg != nil {
@@ -103,9 +107,9 @@ func newOutputInterruptedError(msg *anthropic.Message, cause error) *OutputInter
 // would hide the real cause from callers doing errors.As. Only return the
 // typed error when the partial message actually shows a truncated tool call;
 // otherwise wrap the original error unchanged.
-func classifyAccumulateError(msg *anthropic.Message, cause error) error {
+func classifyAccumulateError(msg *anthropic.Message, cause error, includeThoughts bool) error {
 	if converters.HasIncompleteToolInput(msg) {
-		return newOutputInterruptedError(msg, cause)
+		return newOutputInterruptedError(msg, cause, includeThoughts)
 	}
 	return fmt.Errorf("failed to accumulate message: %w", cause)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -17,6 +17,7 @@ package adkanthropic
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -75,7 +76,7 @@ func TestNewOutputInterruptedError_FromAccumulateFailure(t *testing.T) {
 		t.Fatal("expected Accumulate to fail on the truncated tool input, got nil")
 	}
 
-	err := newOutputInterruptedError(msg, accErr)
+	err := newOutputInterruptedError(msg, accErr, true)
 
 	if err.StopReason != anthropic.StopReasonMaxTokens {
 		t.Errorf("StopReason = %q, want %q", err.StopReason, anthropic.StopReasonMaxTokens)
@@ -118,6 +119,35 @@ func TestNewOutputInterruptedError_FromAccumulateFailure(t *testing.T) {
 	}
 }
 
+func TestNewOutputInterruptedError_HidesUnsignedThoughts(t *testing.T) {
+	unsignedStream := make([]string, 0, len(interruptedToolCallStream)-1)
+	for _, payload := range interruptedToolCallStream {
+		if !strings.Contains(payload, `"type":"signature_delta"`) {
+			unsignedStream = append(unsignedStream, payload)
+		}
+	}
+
+	msg, accErr := accumulateEvents(t, unsignedStream)
+	if accErr == nil {
+		t.Fatal("expected Accumulate to fail on the truncated tool input, got nil")
+	}
+
+	err := newOutputInterruptedError(msg, accErr, false)
+
+	if len(err.Parts) != 2 {
+		t.Fatalf("len(Parts) = %d, want 2 (text and completed tool call)", len(err.Parts))
+	}
+	if err.Parts[0].Thought || err.Parts[0].Text != "Saving the file now." {
+		t.Errorf("Parts[0] = %+v, want completed text without unsigned thinking", err.Parts[0])
+	}
+	if fc := err.Parts[1].FunctionCall; fc == nil || fc.Name != "lookup" || fc.ID != "toolu_ok" {
+		t.Errorf("Parts[1] = %+v, want completed tool call 'lookup'", err.Parts[1])
+	}
+	if err.ToolName != "save_file" || err.PartialInput != `{"path": "/reports/summ` {
+		t.Errorf("interrupted tool = %q input %q, want save_file with partial input", err.ToolName, err.PartialInput)
+	}
+}
+
 func TestNewOutputInterruptedError_MidThinkingNoToolFields(t *testing.T) {
 	// Cut off mid-thinking, before any tool call: the message is valid JSON so
 	// Accumulate succeeds, but if a caller constructs the typed error from this
@@ -137,7 +167,7 @@ func TestNewOutputInterruptedError_MidThinkingNoToolFields(t *testing.T) {
 		t.Fatalf("Accumulate should succeed on a valid mid-thinking message, got %v", accErr)
 	}
 
-	err := newOutputInterruptedError(msg, nil)
+	err := newOutputInterruptedError(msg, nil, true)
 
 	if err.ToolName != "" || err.ToolID != "" || err.PartialInput != "" {
 		t.Errorf("tool fields should be empty for a mid-thinking cut, got name=%q id=%q input=%q", err.ToolName, err.ToolID, err.PartialInput)
@@ -170,7 +200,7 @@ func TestClassifyAccumulateError(t *testing.T) {
 			t.Fatal("expected Accumulate to fail on the truncated tool input, got nil")
 		}
 
-		err := classifyAccumulateError(msg, accErr)
+		err := classifyAccumulateError(msg, accErr, true)
 
 		var interrupted *OutputInterruptedError
 		if !errors.As(err, &interrupted) {
@@ -195,7 +225,7 @@ func TestClassifyAccumulateError(t *testing.T) {
 		}
 
 		sentinel := errors.New("unexpected event shape")
-		err := classifyAccumulateError(msg, sentinel)
+		err := classifyAccumulateError(msg, sentinel, true)
 
 		var interrupted *OutputInterruptedError
 		if errors.As(err, &interrupted) {

--- a/generate_stream_test.go
+++ b/generate_stream_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
 )
 
 // Exact shape Vertex delivers when overload arrives after the 200 OK —
@@ -65,6 +66,22 @@ const thinkingThenOverloadSSE = "event: message_start\n" +
 	"event: content_block_delta\n" +
 	"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"weighing options\"}}\n\n" +
 	overloadedSSE
+
+const thinkingSuccessSSE = "event: message_start\n" +
+	"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"google/gemini-3.6-flash\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":3,\"output_tokens\":0}}}\n\n" +
+	"event: content_block_start\n" +
+	"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}}\n\n" +
+	"event: content_block_delta\n" +
+	"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"weighing options\"}}\n\n" +
+	"event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n" +
+	"event: content_block_start\n" +
+	"data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n" +
+	"event: content_block_delta\n" +
+	"data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n" +
+	"event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n" +
+	"event: message_delta\n" +
+	"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":2}}\n\n" +
+	"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
 
 // newSSEServer answers the i-th request with bodies[i] (repeating the last
 // body once exhausted) and counts requests.
@@ -113,11 +130,21 @@ type streamPair struct {
 
 // collect drains a streaming GenerateContent call into its yielded pairs.
 func collect(ctx context.Context, m *anthropicModel) []streamPair {
+	return collectRequest(ctx, m, &model.LLMRequest{})
+}
+
+func collectRequest(ctx context.Context, m *anthropicModel, req *model.LLMRequest) []streamPair {
 	var pairs []streamPair
-	for resp, err := range m.GenerateContent(ctx, &model.LLMRequest{}, true) {
+	for resp, err := range m.GenerateContent(ctx, req, true) {
 		pairs = append(pairs, streamPair{resp, err})
 	}
 	return pairs
+}
+
+func collectIncludingThoughts(ctx context.Context, m *anthropicModel) []streamPair {
+	return collectRequest(ctx, m, &model.LLMRequest{Config: &genai.GenerateContentConfig{
+		ThinkingConfig: &genai.ThinkingConfig{IncludeThoughts: true},
+	}})
 }
 
 // sseFromPayloads frames raw stream-event payloads (as used by errors_test.go
@@ -243,7 +270,7 @@ func TestGenerateStream_NoRetryAfterThinkingOutput(t *testing.T) {
 	srv, requests := newSSEServer(t, thinkingThenOverloadSSE)
 	m, sleeps := newStreamTestModel(t, srv.URL)
 
-	pairs := collect(t.Context(), m)
+	pairs := collectIncludingThoughts(t.Context(), m)
 
 	if len(pairs) != 2 {
 		t.Fatalf("len(pairs) = %d, want 2 (thinking partial then error)", len(pairs))
@@ -260,6 +287,78 @@ func TestGenerateStream_NoRetryAfterThinkingOutput(t *testing.T) {
 	}
 	if len(*sleeps) != 0 {
 		t.Errorf("sleeps = %d, want 0", len(*sleeps))
+	}
+}
+
+func TestGenerateStream_RetriesAfterHiddenThinking(t *testing.T) {
+	srv, requests := newSSEServer(t, thinkingThenOverloadSSE, successSSE)
+	m, sleeps := newStreamTestModel(t, srv.URL)
+
+	pairs := collect(t.Context(), m)
+
+	if len(pairs) != 2 {
+		t.Fatalf("len(pairs) = %d, want 2 (text partial and final response)", len(pairs))
+	}
+	for _, pair := range pairs {
+		if pair.err != nil {
+			t.Fatalf("unexpected error: %v", pair.err)
+		}
+	}
+	if got := int(requests.Load()); got != 2 {
+		t.Errorf("requests = %d, want 2", got)
+	}
+	if len(*sleeps) != 1 {
+		t.Errorf("sleeps = %d, want 1", len(*sleeps))
+	}
+}
+
+func TestGenerateStream_HonoursIncludeThoughts(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		includeThoughts bool
+		wantPairs       int
+	}{
+		{name: "hidden", includeThoughts: false, wantPairs: 2},
+		{name: "included", includeThoughts: true, wantPairs: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newSSEServer(t, thinkingSuccessSSE)
+			m, _ := newStreamTestModel(t, srv.URL)
+			req := &model.LLMRequest{Config: &genai.GenerateContentConfig{
+				ThinkingConfig: &genai.ThinkingConfig{IncludeThoughts: tc.includeThoughts},
+			}}
+
+			pairs := collectRequest(t.Context(), m, req)
+
+			if len(pairs) != tc.wantPairs {
+				t.Fatalf("len(pairs) = %d, want %d", len(pairs), tc.wantPairs)
+			}
+			for _, pair := range pairs {
+				if pair.err != nil {
+					t.Fatalf("unexpected error: %v", pair.err)
+				}
+			}
+
+			if tc.includeThoughts {
+				if !pairs[0].resp.Partial || !pairs[0].resp.Content.Parts[0].Thought {
+					t.Errorf("pairs[0] = %+v, want partial thinking delta", pairs[0].resp)
+				}
+			} else if pairs[0].resp.Content.Parts[0].Text != "Hello" {
+				t.Errorf("pairs[0] = %+v, want first visible delta to be text", pairs[0].resp)
+			}
+
+			final := pairs[len(pairs)-1].resp
+			if !final.TurnComplete {
+				t.Error("final response TurnComplete = false, want true")
+			}
+			wantFinalParts := 1
+			if tc.includeThoughts {
+				wantFinalParts = 2
+			}
+			if len(final.Content.Parts) != wantFinalParts {
+				t.Fatalf("len(final.Content.Parts) = %d, want %d", len(final.Content.Parts), wantFinalParts)
+			}
+		})
 	}
 }
 
@@ -349,7 +448,7 @@ func TestGenerateStream_InterruptedOutputIsNotRetried(t *testing.T) {
 	srv, requests := newSSEServer(t, sseFromPayloads(t, interruptedToolCallStream))
 	m, sleeps := newStreamTestModel(t, srv.URL)
 
-	pairs := collect(t.Context(), m)
+	pairs := collectIncludingThoughts(t.Context(), m)
 
 	// The fixture streams a thinking delta and a text delta before the
 	// truncated tool call, so those arrive as partials ahead of the error.


### PR DESCRIPTION
## Problem

- Anthropic-compatible gateways such as Vercel AI Gateway can reject Gemini tool requests when a JSON Schema union loses its allowed types.
- Some gateways return unsigned Gemini reasoning even when the request asks to omit thoughts.

## Solution

- Convert multi-type JSON Schema definitions into Anthropic `anyOf` schemas.
- Hide unsigned reasoning when `IncludeThoughts` is false, while preserving signed and redacted provider state for later requests.
